### PR TITLE
fix: Improve Blackwell GPU support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ FluxVLA Engine is a full-stack, end-to-end engineering platform for deploying em
 
 ## 🛠️ Installation
 
-The installation guide below uses NVCC 12.4 as an example. If your environment differs, adjust the CUDA version accordingly.
-
 <details>
 <summary><b>1. Create a conda environment</b></summary>
 
@@ -64,10 +62,11 @@ conda activate fluxvla
 > **Important**: Before running `pip install -r requirements.txt`, you must install PyTorch from the official CUDA index first. The default PyPI index cannot fetch CUDA-enabled builds.
 
 ```bash
-pip install torch==2.6.0 torchvision==0.21.0 torchaudio==2.6.0 --index-url https://download.pytorch.org/whl/cu124
+# CUDA 12.8
+pip install torch==2.8.0 torchvision==0.23.0 torchaudio==2.8.0 --index-url https://download.pytorch.org/whl/cu128
 ```
 
-For other CUDA versions, replace `cu124` with the corresponding value (e.g., `cu118`, `cu121`). See: [https://pytorch.org/get-started/locally/](https://pytorch.org/get-started/locally/) .
+For other CUDA versions, replace `cu128` with the corresponding value (e.g., `cu118`, `cu121`). See: [https://pytorch.org/get-started/locally/](https://pytorch.org/get-started/locally/) and [https://pytorch.org/get-started/previous-versions/](https://pytorch.org/get-started/previous-versions/).
 
 </details>
 
@@ -581,16 +580,6 @@ pip install numpy==1.26.4
 
 </details>
 
-<details>
-<summary><b>Q: Inference fails on RTX 5090 (e.g., Triton kernel errors or CUDA compatibility issues).</b></summary>
-
-<b>A:</b> RTX 5090 (Blackwell architecture) requires an updated Triton version. Upgrade to Triton 3.2.0 or higher:
-
-```bash
-pip install triton==3.2.0
-```
-
-</details>
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -580,7 +580,6 @@ pip install numpy==1.26.4
 
 </details>
 
-
 ## Contributing
 
 Please see the contribution workflow and guidelines in [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md).

--- a/README_ja.md
+++ b/README_ja.md
@@ -45,8 +45,6 @@ FluxVLA Engine は、具現知能（Embodied Intelligence）の実運用を見�
 
 ## 🛠️ インストール
 
-以下のインストール手順は NVCC 12.4 を例にしています。環境が異なる場合は、CUDA バージョンに応じて適宜調整してください。
-
 <details>
 <summary><b>1. conda 環境を作成する</b></summary>
 
@@ -63,10 +61,11 @@ conda activate fluxvla
 > **重要**：`pip install -r requirements.txt` を実行する前に、必ず公式の CUDA インデックスから PyTorch を先にインストールしてください。デフォルトの PyPI インデックスでは CUDA 対応ビルドを取得できません。
 
 ```bash
-pip install torch==2.6.0 torchvision==0.21.0 torchaudio==2.6.0 --index-url https://download.pytorch.org/whl/cu124
+# CUDA 12.8
+pip install torch==2.8.0 torchvision==0.23.0 torchaudio==2.8.0 --index-url https://download.pytorch.org/whl/cu128
 ```
 
-他の CUDA バージョンの場合は、`cu124` を該当する値（例：`cu118`、`cu121`）に置き換えてください。詳細は [https://pytorch.org/get-started/locally/](https://pytorch.org/get-started/locally/) を参照してください。
+他の CUDA バージョンの場合は、`cu128` を該当する値（例：`cu118`、`cu121`）に置き換えてください。詳細は [https://pytorch.org/get-started/locally/](https://pytorch.org/get-started/locally/) および [https://pytorch.org/get-started/previous-versions/](https://pytorch.org/get-started/previous-versions/) を参照してください。
 
 </details>
 
@@ -110,7 +109,7 @@ pip install -r requirements.txt
 pip install --no-build-isolation -e .
 ```
 
-> **補足**：`requirements.txt` では `torch==2.6.0` を固定しています。これにより、2 番目の手順でインストールした CUDA 対応 PyTorch を pip が意図せず置き換えるのを防ぎます。別の torch バージョンを使う必要がある場合は、2 番目のコマンドと `requirements.txt` 内のバージョンの両方を更新してください。
+> **補足**：`requirements.txt` では `torch==2.8.0` を固定しています。これにより、2 番目の手順でインストールした CUDA 対応 PyTorch を pip が意図せず置き換えるのを防ぎます。別の torch バージョンを使う必要がある場合は、2 番目のコマンドと `requirements.txt` 内のバージョンの両方を更新してください。
 
 </details>
 
@@ -574,17 +573,6 @@ CMAKE_POLICY_VERSION_MINIMUM=3.5 pip install -r requirements.txt
 
 ```bash
 pip install numpy==1.26.4
-```
-
-</details>
-
-<details>
-<summary><b>Q：RTX 5090（推論）で失敗する（例：Triton カーネルのエラーや CUDA 互換性の問題）。</b></summary>
-
-<b>A：</b> RTX 5090（Blackwell アーキテクチャ）は更新された Triton が必要です。Triton 3.2.0 以上にアップグレードしてください：
-
-```bash
-pip install triton==3.2.0
 ```
 
 </details>

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -45,8 +45,6 @@ FluxVLA Engine是面向具身智能落地应用的全链路一体化工程平台
 
 ## 🛠️ 安装
 
-以下安装指南以 NVCC 12.4 为例。如果你的环境不同，请相应调整 CUDA 版本。
-
 <details>
 <summary><b>1. 创建 conda 环境</b></summary>
 
@@ -63,10 +61,11 @@ conda activate fluxvla
 > **重要**：在执行 `pip install -r requirements.txt` 之前，**必须**先从官方 CUDA 索引安装 PyTorch。默认 PyPI 索引无法获取 CUDA 版本构建。
 
 ```bash
-pip install torch==2.6.0 torchvision==0.21.0 torchaudio==2.6.0 --index-url https://download.pytorch.org/whl/cu124
+# CUDA 12.8
+pip install torch==2.8.0 torchvision==0.23.0 torchaudio==2.8.0 --index-url https://download.pytorch.org/whl/cu128
 ```
 
-对于其他 CUDA 版本，请将 `cu124` 替换为对应值（例如 `cu118`、`cu121`）。详见 [https://pytorch.org/get-started/locally/](https://pytorch.org/get-started/locally/) 。
+对于其他 CUDA 版本，请将 `cu128` 替换为对应值（例如 `cu118`、`cu121`）。详见 [https://pytorch.org/get-started/locally/](https://pytorch.org/get-started/locally/) 和 [https://pytorch.org/get-started/previous-versions/](https://pytorch.org/get-started/previous-versions/)。
 
 </details>
 
@@ -110,7 +109,7 @@ pip install -r requirements.txt
 pip install --no-build-isolation -e .
 ```
 
-> **说明**：`requirements.txt` 固定了 `torch==2.6.0`，以避免 pip 意外替换掉第 2 步安装的 CUDA 版 PyTorch。若需使用其他 torch 版本，请同时更新第 2 步命令与 `requirements.txt` 中的版本。
+> **说明**：`requirements.txt` 固定了 `torch==2.8.0`，以避免 pip 意外替换掉第 2 步安装的 CUDA 版 PyTorch。若需使用其他 torch 版本，请同时更新第 2 步命令与 `requirements.txt` 中的版本。
 
 </details>
 
@@ -574,17 +573,6 @@ A：安装过程中某些依赖可能覆盖了固定的 NumPy 版本。直接重
 
 ```bash
 pip install numpy==1.26.4
-```
-
-</details>
-
-<details>
-<summary><b>Q：在 RTX 5090 上推理失败（如 Triton kernel 错误或 CUDA 兼容性问题）。</b></summary>
-
-A：RTX 5090（Blackwell 架构）需要更新版本的 Triton。请升级到 Triton 3.2.0 或更高版本：
-
-```bash
-pip install triton==3.2.0
 ```
 
 </details>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-torch==2.8.0
-torchvision==0.23.0
-torchaudio==2.8.0
+torch>=2.6.0
+torchvision>=0.21.0
+torchaudio>=2.6.0
 accelerate==0.33.0
 bddl==1.0.1
 boto3==1.38.32

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-torch==2.6.0
-torchvision==0.21.0
-torchaudio==2.6.0
+torch==2.8.0
+torchvision==0.23.0
+torchaudio==2.8.0
 accelerate==0.33.0
 bddl==1.0.1
 boto3==1.38.32


### PR DESCRIPTION
Solve #29 
Tested on:
- Ubuntu 24.04
- CUDA 12.8.2
- PYTHON 3.10
- RTX 5090

Training and inference of libero works well, no other errors.