### PR TITLE
[Doc] Fix dataset structure docs and add h5py dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,30 +620,32 @@ The converted dataset should follow this directory structure:
 
 ```
 ├── data
-│   └── chunk000
+│   └── chunk-000
 │   │   └── episode_000000.parquet
 │   │   └── episode_000001.parquet
 │   │   └── ... (more parquet files)
 │   │   └── episode_00000N.parquet
-│   └── chunk001
+│   └── chunk-001
 │   └── ... (more chunks)
-│   └── chunk00N
+│   └── chunk-00N
 ├── meta
 │   └── episodes.jsonl
 │   └── episodes_stats.jsonl
 │   └── info.json
 │   └── tasks.jsonl
 ├── videos
-│   └── chunk000
+│   └── chunk-000
 │   │   └── camera name 0
 │   │   │   └── episode_000000.mp4
 │   │   │   └── episode_000001.mp4
 │   │   │   └── ...(more mp4 files)
 │   │   │   └── episode_00000N.mp4
 │   │   └── camera name 1
-│   └── chunk001
+│   │   └── ...(more cameras)
+│   │   └── camera name N
+│   └── chunk-001
 │   └── ... (more chunks)
-│   └── chunk00N
+│   └── chunk-00N
 ```
 
 </details>

--- a/README_ja.md
+++ b/README_ja.md
@@ -573,30 +573,32 @@ SARM については、必要な SARM アノテーション列が含まれてい
 
 ```
 ├── data
-│   └── chunk000
+│   └── chunk-000
 │   │   └── episode_000000.parquet
 │   │   └── episode_000001.parquet
 │   │   └── ...（さらに多くの parquet ファイル）
 │   │   └── episode_00000N.parquet
-│   └── chunk001
+│   └── chunk-001
 │   └── ...（さらに多くの chunk）
-│   └── chunk00N
+│   └── chunk-00N
 ├── meta
 │   └── episodes.jsonl
 │   └── episodes_stats.jsonl
 │   └── info.json
 │   └── tasks.jsonl
 ├── videos
-│   └── chunk000
+│   └── chunk-000
 │   │   └── camera name 0
 │   │   │   └── episode_000000.mp4
 │   │   │   └── episode_000001.mp4
 │   │   │   └── ...（さらに多くの mp4 ファイル）
 │   │   │   └── episode_00000N.mp4
 │   │   └── camera name 1
-│   └── chunk001
+│   │   └── ...（さらに多くのカメラ）
+│   │   └── camera name N
+│   └── chunk-001
 │   └── ...（さらに多くの chunk）
-│   └── chunk00N
+│   └── chunk-00N
 ```
 
 </details>

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -567,30 +567,32 @@ huggingface-cli download limxdynamics/FluxVLAData --repo-type dataset --include 
 
 ```
 ├── data
-│   └── chunk000
+│   └── chunk-000
 │   │   └── episode_000000.parquet
 │   │   └── episode_000001.parquet
 │   │   └── ... (更多 parquet 文件)
 │   │   └── episode_00000N.parquet
-│   └── chunk001
+│   └── chunk-001
 │   └── ... (更多 chunk)
-│   └── chunk00N
+│   └── chunk-00N
 ├── meta
 │   └── episodes.jsonl
 │   └── episodes_stats.jsonl
 │   └── info.json
 │   └── tasks.jsonl
 ├── videos
-│   └── chunk000
+│   └── chunk-000
 │   │   └── camera name 0
 │   │   │   └── episode_000000.mp4
 │   │   │   └── episode_000001.mp4
 │   │   │   └── ...(更多 mp4 文件)
 │   │   │   └── episode_00000N.mp4
 │   │   └── camera name 1
-│   └── chunk001
+│   │   └── ...(更多相机)
+│   │   └── camera name N
+│   └── chunk-001
 │   └── ... (更多 chunk)
-│   └── chunk00N
+│   └── chunk-00N
 ```
 
 </details>

--- a/docs/data_convert.md
+++ b/docs/data_convert.md
@@ -9,7 +9,7 @@ Data conversion tool: Convert HDF5 format data collected by the ALOHA dual-arm r
    ```bash
    conda create -y -n lerobot python=3.10
    conda activate lerobot
-   conda install -c conda-forge ffmpeg av
+   conda install -c conda-forge ffmpeg av h5py
    ```
 
 2. Install lerobot
@@ -80,18 +80,32 @@ ______________________________________________________________________
 The converted dataset follows the LeRobot v2.1 format, stored in a HuggingFace Datasets-compatible directory structure:
 
 ```
-<output_dir>/<repo_id>/
-├── data/
-│   ├── train/
-│   │   ├── episode_0.parquet
-│   │   └── ...
-│   └── video/
-│       ├── episode_0/
-│       │   ├── observation.images.head_cam.mp4
-│       │   └── ...
-│       └── ...
-├── info.json
-└── meta.json
+├── data
+│   └── chunk-000
+│   │   └── episode_000000.parquet
+│   │   └── episode_000001.parquet
+│   │   └── ... (more parquet files)
+│   │   └── episode_00000N.parquet
+│   └── chunk-001
+│   └── ... (more chunks)
+│   └── chunk-00N
+├── meta
+│   └── episodes.jsonl
+│   └── episodes_stats.jsonl
+│   └── info.json
+│   └── tasks.jsonl
+├── videos
+│   └── chunk-000
+│   │   └── camera name 0
+│   │   │   └── episode_000000.mp4
+│   │   │   └── episode_000001.mp4
+│   │   │   └── ...(more mp4 files)
+│   │   │   └── episode_00000N.mp4
+│   │   └── camera name 1
+│   │   └── camera name 2
+│   └── chunk-001
+│   └── ... (more chunks)
+│   └── chunk-00N
 ```
 
 #### Data Field Descriptions


### PR DESCRIPTION
- Correct converted dataset layout to LeRobot v2.1 format (chunk-000 naming, meta/videos structure) across all READMEs
- Update docs/data_convert.md directory tree and add h5py to the conda install command