### PR TITLE
[Fix] Correct LIBERO eval progress and output defaults

### DIFF
--- a/fluxvla/datasets/dataset_wrapper.py
+++ b/fluxvla/datasets/dataset_wrapper.py
@@ -340,8 +340,10 @@ class DistributedRepeatingDataset(IterableDataset):
             # Apply dimension padding to individual
             # dataset statistics if dim is specified
             if self.dim is not None:
-                for stat_type in ['min', 'max', 'mean', 'std', 'q01',
-                                  'q99']:  # noqa: E501
+                for stat_type in [
+                        'min', 'max', 'mean', 'std', 'count', 'q01', 'q99',
+                        'q25', 'q50', 'q75'
+                ]:
                     if stat_type in key_stats and len(
                             key_stats[stat_type]) > 0:
                         padded_stats = []
@@ -352,78 +354,27 @@ class DistributedRepeatingDataset(IterableDataset):
                         key_stats[stat_type] = padded_stats
 
             # Global min and max
-            global_min = np.array(key_stats['min']).min(axis=0).tolist()
-            global_max = np.array(key_stats['max']).max(axis=0).tolist()
+            global_min = np.asarray(
+                key_stats['min'], dtype=np.float64).min(axis=0).tolist()
+            global_max = np.asarray(
+                key_stats['max'], dtype=np.float64).max(axis=0).tolist()
 
-            # Compute weighted mean and combined std
-            if 'count' in key_stats and len(key_stats['count']) > 0:
-                # If count information is available,
-                # use it for weighted calculations
-                means = np.array(key_stats['mean'])
-                counts = np.array(key_stats['count']).repeat(means.shape[1], 1)
-                stds = np.array(key_stats['std'])
+            means = np.asarray(key_stats['mean'], dtype=np.float64)
+            stds = np.asarray(key_stats['std'], dtype=np.float64)
+            counts = self._counts_to_weights(key_stats, means, key)
 
-                # Weighted mean
-                total_count = counts.sum()
-                if total_count > 0:
-                    weighted_mean = np.average(
-                        means, weights=counts, axis=0).tolist()
+            weighted_mean, combined_std = self._combine_mean_and_std(
+                means, stds, counts)
+            weighted_mean = weighted_mean.tolist()
+            combined_std = combined_std.tolist()
 
-                    # Merge standard deviations using the formula:
-                    # Var_combined = Σ(n_i * (σ_i^2 + (μ_i -
-                    # μ_combined)^2)) / Σn_i
-                    variances = stds**2
-                    mean_diffs_sq = (means - weighted_mean)**2
-
-                    combined_variance = np.sum(
-                        counts *
-                        (variances + mean_diffs_sq), axis=0) / total_count
-                    combined_std = np.sqrt(combined_variance).tolist()
-                else:
-                    weighted_mean = np.array(
-                        key_stats['mean']).mean(axis=0).tolist()
-                    combined_std = np.array(
-                        key_stats['std']).mean(axis=0).tolist()
-            else:
-                # if no count information, use simple averages
-                weighted_mean = np.array(
-                    key_stats['mean']).mean(axis=0).tolist()
-
-                # mean of stds as an approximation
-                stds = np.array(key_stats['std'])
-                combined_std = np.sqrt(np.mean(stds**2, axis=0)).tolist()
-
-            # Handle quantiles
-            # Ideally, we would want to merge quantiles more accurately,
-            # but without raw data, we can only approximate.
-
-            # Approach:
-            # 1: Use weighted average if counts are available
-            # 2: Use median of quantiles as a fallback
-            # 3: If neither is available, set to None
-
-            q01_value = None
-            q99_value = None
-
-            if 'q01' in key_stats and len(key_stats['q01']) > 0:
-                q01_array = np.array(key_stats['q01'])
-                if 'count' in key_stats and len(key_stats['count']) > 0:
-                    # Weighted average
-                    q01_value = np.average(
-                        q01_array, weights=counts, axis=0).tolist()
-                else:
-                    # Use median as a compromise
-                    q01_value = np.median(q01_array, axis=0).tolist()
-
-            if 'q99' in key_stats and len(key_stats['q99']) > 0:
-                q99_array = np.array(key_stats['q99'])
-                if 'count' in key_stats and len(key_stats['count']) > 0:
-                    # Weighted average
-                    q99_value = np.average(
-                        q99_array, weights=counts, axis=0).tolist()
-                else:
-                    # Use median as a compromise
-                    q99_value = np.median(q99_array, axis=0).tolist()
+            # Quantiles can only be approximated without raw samples. Use
+            # count-weighted averaging when every dataset provides a compatible
+            # count; otherwise median is the least surprising fallback.
+            q01_value = self._combine_optional_statistic(
+                key_stats, 'q01', counts, len(means))
+            q99_value = self._combine_optional_statistic(
+                key_stats, 'q99', counts, len(means))
 
             # Set combined statistics for all mapped keys
             for mapped_key in mapped_keys:
@@ -438,24 +389,103 @@ class DistributedRepeatingDataset(IterableDataset):
 
                 # Add other quantiles if available
                 for q in ['q25', 'q50', 'q75']:
-                    if q in key_stats and len(key_stats[q]) > 0:
-                        q_array = np.array(key_stats[q])
-                        if 'count' in key_stats and len(
-                                key_stats['count']) > 0:
-                            q_value = np.average(
-                                q_array, weights=counts, axis=0).tolist()
-                        else:
-                            q_value = np.median(q_array, axis=0).tolist()
+                    q_value = self._combine_optional_statistic(
+                        key_stats, q, counts, len(means))
+                    if q_value is not None:
                         metadata[mapped_key][q] = q_value
 
         return {self.statistic_name: metadata}
+
+    def _combine_mean_and_std(self, means, stds, weights=None):
+        """Merge per-dataset mean/std into global population statistics."""
+        if weights is None:
+            mean = means.mean(axis=0)
+            variance = np.mean(stds**2 + (means - mean)**2, axis=0)
+        else:
+            mean = self._weighted_average(means, weights)
+            variance = self._weighted_average(stds**2 + (means - mean)**2,
+                                              weights)
+
+        return mean, np.sqrt(np.maximum(variance, 0.0))
+
+    def _combine_optional_statistic(self, key_stats, stat_type, weights,
+                                    expected_num_stats):
+        if stat_type not in key_stats or len(key_stats[stat_type]) == 0:
+            return None
+
+        values = np.asarray(key_stats[stat_type], dtype=np.float64)
+        if weights is not None and len(
+                key_stats[stat_type]) == expected_num_stats:
+            try:
+                return self._weighted_average(values, weights).tolist()
+            except ValueError:
+                pass
+
+        return np.median(values, axis=0).tolist()
+
+    def _counts_to_weights(self, key_stats, values, stat_key):
+        counts = key_stats.get('count')
+        if counts is None or len(counts) != len(values):
+            return None
+
+        counts = np.asarray(counts, dtype=np.float64)
+        if counts.shape[0] != values.shape[0]:
+            return None
+        if np.any(counts < 0):
+            raise ValueError(
+                f"Negative dataset count in statistic '{stat_key}'")
+
+        if values.ndim == 1:
+            if counts.ndim > 1 and np.prod(counts.shape[1:]) != 1:
+                raise ValueError(
+                    f'Count shape {counts.shape} is incompatible with '
+                    f"statistic '{stat_key}' shape {values.shape}")
+            weights = counts.reshape(counts.shape[0])
+        else:
+            value_shape = values.shape[1:]
+            if counts.ndim == 1:
+                weights = counts.reshape((-1, ) + (1, ) * len(value_shape))
+            elif counts.shape[1:] == value_shape:
+                weights = counts
+            elif np.prod(counts.shape[1:]) == 1:
+                weights = counts.reshape((-1, ) + (1, ) * len(value_shape))
+            else:
+                raise ValueError(
+                    f'Count shape {counts.shape} is incompatible with '
+                    f"statistic '{stat_key}' shape {values.shape}")
+
+        try:
+            broadcast_weights = self._broadcast_weights_for_values(
+                weights, values)
+        except ValueError as exc:
+            raise ValueError(
+                f'Count shape {counts.shape} is incompatible with '
+                f"statistic '{stat_key}' shape {values.shape}") from exc
+
+        if np.any(broadcast_weights.sum(axis=0) <= 0):
+            return None
+
+        return weights
+
+    def _weighted_average(self, values, weights):
+        values = np.asarray(values, dtype=np.float64)
+        weights = self._broadcast_weights_for_values(weights, values)
+        total_weight = weights.sum(axis=0)
+        if np.any(total_weight <= 0):
+            raise ValueError('Weights must have positive sum.')
+        return np.sum(values * weights, axis=0) / total_weight
+
+    def _broadcast_weights_for_values(self, weights, values):
+        weights = np.asarray(weights, dtype=np.float64)
+        values = np.asarray(values, dtype=np.float64)
+        return np.broadcast_to(weights, values.shape)
 
     def _pad_statistics_to_dim(self, stats_dict):
         """Pad statistics to be an integer multiple of self.dim.
 
         Args:
             stats_dict: Dictionary containing statistics
-                (mean, std, min, max, q01, q99)
+                (mean, std, min, max, count, q01, q99, q25, q50, q75)
 
         Returns:
             Dictionary with padded statistics
@@ -465,25 +495,27 @@ class DistributedRepeatingDataset(IterableDataset):
 
         padded_stats = {}
         for key, value in stats_dict.items():
-            if isinstance(value, (list, np.ndarray)) and len(value) > 0:
-                # Convert to numpy array for easier manipulation
-                if isinstance(value, list):
-                    value = np.array(value)
+            if isinstance(value, (list, np.ndarray)):
+                array_value = np.asarray(value)
+                if array_value.ndim == 0 or array_value.size == 0:
+                    padded_stats[key] = array_value.item(
+                    ) if array_value.ndim == 0 else value
+                    continue
 
                 # Get the first dimension (sequence length)
-                orig_len = value.shape[0]
+                orig_len = array_value.shape[0]
                 # Calculate target length as integer multiple of dim
                 target_len = ((orig_len + self.dim - 1) // self.dim) * self.dim
 
                 if target_len == orig_len:
                     # No padding needed
-                    padded_stats[key] = value.tolist() if isinstance(
-                        value, np.ndarray) else value
+                    padded_stats[key] = array_value.tolist()
                 else:
                     # Pad by copying the original data
                     repeat_times = (target_len + orig_len - 1) // orig_len
-                    padded_value = np.tile(value, (repeat_times, ) + (1, ) *
-                                           (value.ndim - 1))[:target_len]
+                    padded_value = np.tile(array_value,
+                                           (repeat_times, ) + (1, ) *
+                                           (array_value.ndim - 1))[:target_len]
                     padded_stats[key] = padded_value.tolist()
             else:
                 # Non-array data or scalar, keep as is

--- a/fluxvla/engines/runners/libero_eval_runner.py
+++ b/fluxvla/engines/runners/libero_eval_runner.py
@@ -216,6 +216,31 @@ class LiberoEvalRunner(BaseEvalRunner):
         ]
 
     @staticmethod
+    def _write_rank_progress(progress_dir: str, rank: int, episodes: int,
+                             successes: int) -> None:
+        os.makedirs(progress_dir, exist_ok=True)
+        progress_path = os.path.join(progress_dir, f'rank{rank}.json')
+        tmp_path = f'{progress_path}.tmp'
+        with open(tmp_path, 'w', encoding='utf-8') as f:
+            json.dump(
+                dict(rank=rank, episodes=episodes, successes=successes), f)
+        os.replace(tmp_path, progress_path)
+
+    @staticmethod
+    def _read_rank_progress(progress_dir: str) -> tuple:
+        total_episodes = 0
+        total_successes = 0
+        for progress_path in Path(progress_dir).glob('rank*.json'):
+            try:
+                with open(progress_path, 'r', encoding='utf-8') as f:
+                    progress = json.load(f)
+                total_episodes += int(progress.get('episodes', 0))
+                total_successes += int(progress.get('successes', 0))
+            except (OSError, json.JSONDecodeError, TypeError, ValueError):
+                continue
+        return total_episodes, total_successes
+
+    @staticmethod
     def _get_max_steps(task_suite_name: str, override: int = None) -> int:
         """Per-suite rollout horizon."""
         suite_steps = {
@@ -563,6 +588,10 @@ class LiberoEvalRunner(BaseEvalRunner):
         self.run_dir = self._build_run_dir(
             self.ckpt_path, run_id, output_dir=self.result_output_dir)
         os.makedirs(self.run_dir, exist_ok=True)
+        progress_dir = os.path.join(self.run_dir, 'rank_progress')
+        total_eval_episodes = len(
+            self._build_global_episodes(num_tasks, self.num_trials_per_task,
+                                        task_ids))
         local_log_filepath = self._build_log_file_path(self.ckpt_path, run_id,
                                                        rank,
                                                        self.result_output_dir)
@@ -584,8 +613,8 @@ class LiberoEvalRunner(BaseEvalRunner):
                 'not found in VLA norm_stats!')
         if rank == 0:
             pbar = tqdm.tqdm(
-                total=len(local_episodes),
-                desc='Evaluation rank0',
+                total=total_eval_episodes,
+                desc='Evaluation global',
                 dynamic_ncols=True)
         else:
             pbar = None
@@ -762,12 +791,30 @@ class LiberoEvalRunner(BaseEvalRunner):
                         save_multi_view=self.save_multi_view_rollout_videos)
                 rank_success_rate = (
                     rank_success_count / rank_episode_count * 100)
+                self._write_rank_progress(progress_dir, rank,
+                                          rank_episode_count,
+                                          rank_success_count)
+                display_episode_count = rank_episode_count
+                display_success_count = rank_success_count
+                display_success_rate = rank_success_rate
                 if rank == 0 and pbar is not None:
+                    display_episode_count, display_success_count = \
+                        self._read_rank_progress(progress_dir)
+                    display_success_rate = (
+                        display_success_count / max(display_episode_count, 1) *
+                        100)
+                    pbar_delta = max(display_episode_count - pbar.n, 0)
+                    overwatch.info('[eval-progress] '
+                                   f'episodes={display_episode_count}/'
+                                   f'{total_eval_episodes} '
+                                   f'successes={display_success_count} '
+                                   f'success_rate={display_success_rate:.2f}%')
                     pbar.set_postfix(
-                        successes=rank_success_count,
-                        episodes=rank_episode_count,
-                        success_rate=f'{rank_success_rate:.1f}%')
-                    pbar.update(1)
+                        successes=display_success_count,
+                        episodes=display_episode_count,
+                        success_rate=f'{display_success_rate:.1f}%')
+                    if pbar_delta > 0:
+                        pbar.update(pbar_delta)
 
                 # except Exception as e:
                 #     print(f'Error during action prediction: {e}')

--- a/fluxvla/engines/utils/eval_utils.py
+++ b/fluxvla/engines/utils/eval_utils.py
@@ -449,7 +449,6 @@ def save_rollout_video(rollout_images,
             frame = np.array(img)
         video_writer.append_data(frame)
     video_writer.close()
-    print(f'Saved rollout MP4 at path {mp4_path}')
     if log_file is not None:
         log_file.write(f'Saved rollout MP4 at path {mp4_path}\n')
     return mp4_path

--- a/scripts/eval_libero_manager.sh
+++ b/scripts/eval_libero_manager.sh
@@ -28,9 +28,12 @@
 # Defaults are resolved as: environment override -> config value -> built-in
 # fallback. Manager-only defaults should be set in config via
 # ``eval = dict(runner=dict(...), manager=dict(...))``.
+# If OUTPUT_DIR is unset, the manager uses eval.manager.output_dir, then
+# eval.runner.result_output_dir, then a timestamped work_dirs fallback.
 #
 # OUTPUT_DIR layout:
-#   summary.{csv,txt,json}, task_success_rates.csv, failed_tasks.txt,
+#   summary.{csv,txt,json}, suite_success_rates.csv,
+#   task_success_rates.csv, failed_tasks.txt,
 #   task_logs/, task_status/, <suite>/gpuX_taskY_results.json,
 #   <suite>/videos/*.mp4 unless ROLLOUT_DIR/eval.rollout_dir overrides it
 #
@@ -54,7 +57,7 @@ PREPROCESS_EVERY_STEP="${PREPROCESS_EVERY_STEP:-}"
 SAVE_FAILED_ROLLOUT_VIDEOS="${SAVE_FAILED_ROLLOUT_VIDEOS:-}"
 SAVE_MULTI_VIEW_ROLLOUT_VIDEOS="${SAVE_MULTI_VIEW_ROLLOUT_VIDEOS:-}"
 ROLLOUT_DIR="${ROLLOUT_DIR:-}"
-OUTPUT_DIR="${OUTPUT_DIR:-work_dirs/libero_eval_manager/$(date +%Y%m%d_%H%M%S)}"
+OUTPUT_DIR="${OUTPUT_DIR:-}"
 EXTRA_ARGS=("$@")
 
 DEFAULT_SUITES="libero_10 libero_goal libero_spatial libero_object"
@@ -84,6 +87,7 @@ CFG_STATUS_INTERVAL=""
 CFG_LAUNCH_DELAY=""
 CFG_SUMMARY_TOOL=""
 CFG_TASK_FILE=""
+CFG_OUTPUT_DIR=""
 CFG_SAVE_ROLLOUT_VIDEOS=""
 CFG_SAVE_MULTI_VIEW_ROLLOUT_VIDEOS=""
 CFG_ROLLOUT_DIR=""
@@ -103,6 +107,7 @@ while IFS=$'\t' read -r key value; do
     CFG_LAUNCH_DELAY) CFG_LAUNCH_DELAY="${value}" ;;
     CFG_SUMMARY_TOOL) CFG_SUMMARY_TOOL="${value}" ;;
     CFG_TASK_FILE) CFG_TASK_FILE="${value}" ;;
+    CFG_OUTPUT_DIR) CFG_OUTPUT_DIR="${value}" ;;
     CFG_SAVE_ROLLOUT_VIDEOS) CFG_SAVE_ROLLOUT_VIDEOS="${value}" ;;
     CFG_SAVE_MULTI_VIEW_ROLLOUT_VIDEOS) CFG_SAVE_MULTI_VIEW_ROLLOUT_VIDEOS="${value}" ;;
     CFG_ROLLOUT_DIR) CFG_ROLLOUT_DIR="${value}" ;;
@@ -163,6 +168,9 @@ fields = {
     'CFG_LAUNCH_DELAY': ('eval.manager.launch_delay', ),
     'CFG_SUMMARY_TOOL': ('eval.manager.summary_tool', ),
     'CFG_TASK_FILE': ('eval.manager.task_file', ),
+    'CFG_OUTPUT_DIR': (
+        'eval.manager.output_dir', 'eval.runner.result_output_dir',
+        'eval.output_dir', 'eval.result_output_dir'),
     'CFG_SAVE_ROLLOUT_VIDEOS': (
         'eval.runner.save_rollout_videos', 'eval.save_rollout_videos'),
     'CFG_SAVE_MULTI_VIEW_ROLLOUT_VIDEOS': (
@@ -177,6 +185,16 @@ PY
 )
 
 EVAL_RUNNER_PREFIX="${CFG_EVAL_RUNNER_PREFIX:-eval}"
+
+if [[ -n "${OUTPUT_DIR:-}" ]]; then
+  OUTPUT_DIR_SOURCE="env"
+elif [[ -n "${CFG_OUTPUT_DIR}" ]]; then
+  OUTPUT_DIR="${CFG_OUTPUT_DIR}"
+  OUTPUT_DIR_SOURCE="config"
+else
+  OUTPUT_DIR="work_dirs/libero_eval_manager/$(date +%Y%m%d_%H%M%S)"
+  OUTPUT_DIR_SOURCE="default"
+fi
 
 if [[ -n "${SUITES:-}" ]]; then
   SUITES_SOURCE="env"
@@ -210,6 +228,8 @@ fi
 
 if [[ -n "${MASTER_PORT_BASE:-}" ]]; then
   :
+elif [[ -n "${MASTER_PORT:-}" ]]; then
+  MASTER_PORT_BASE="${MASTER_PORT}"
 elif [[ -n "${CFG_MASTER_PORT_BASE}" ]]; then
   MASTER_PORT_BASE="${CFG_MASTER_PORT_BASE}"
 else
@@ -417,6 +437,7 @@ write_manager_config() {
     echo "save_multi_view_rollout_videos: ${SAVE_MULTI_VIEW_ROLLOUT_VIDEOS:-config default}"
     echo "rollout_dir: ${ROLLOUT_DIR:-default}"
     echo "output_dir: ${OUTPUT_DIR}"
+    echo "output_dir_source: ${OUTPUT_DIR_SOURCE}"
     echo "task_file: ${task_file}"
   } > "${OUTPUT_DIR}/manager_config.yaml"
 }
@@ -443,9 +464,11 @@ if [[ "${total_tasks}" -eq 0 ]]; then
 fi
 
 declare -A SEEN_SUITES
+declare -A SUITE_TOTAL_TASKS
 SUITE_ORDER=()
 for task_entry in "${TASK_QUEUE[@]}"; do
   suite_name="${task_entry%%,*}"
+  SUITE_TOTAL_TASKS["${suite_name}"]=$((${SUITE_TOTAL_TASKS[${suite_name}]:-0} + 1))
   if [[ -z "${SEEN_SUITES[${suite_name}]:-}" ]]; then
     SUITE_ORDER+=("${suite_name}")
     SEEN_SUITES["${suite_name}"]=1
@@ -461,6 +484,7 @@ overall_eval_episodes=0
 
 declare -A SUITE_EVAL_SUCCESSES
 declare -A SUITE_EVAL_EPISODES
+declare -A SUITE_COMPLETED_TASKS
 
 running_pids=()
 running_gpus=()
@@ -589,6 +613,23 @@ print(f'{successes / max(episodes, 1) * 100:.2f}')
 PY
 }
 
+write_suite_success_rates_file() {
+  local output_file="${OUTPUT_DIR}/suite_success_rates.csv"
+  {
+    echo "Suite,Completed Tasks,Total Tasks,Successes,Episodes,Success Rate (%)"
+    local suite_name
+    for suite_name in "${SUITE_ORDER[@]}"; do
+      local completed="${SUITE_COMPLETED_TASKS[${suite_name}]:-0}"
+      local total="${SUITE_TOTAL_TASKS[${suite_name}]:-0}"
+      local successes="${SUITE_EVAL_SUCCESSES[${suite_name}]:-0}"
+      local episodes="${SUITE_EVAL_EPISODES[${suite_name}]:-0}"
+      local success_rate
+      success_rate="$(format_success_rate "${successes}" "${episodes}")"
+      echo "${suite_name},${completed},${total},${successes},${episodes},${success_rate}"
+    done
+  } > "${output_file}"
+}
+
 format_eval_success_rate() {
   format_success_rate "${overall_eval_successes}" \
     "${overall_eval_episodes}"
@@ -665,14 +706,18 @@ poll_finished_tasks() {
       status="${status_line%%|*}"
       wait "${pid}" 2>/dev/null || true
       GPU_LOAD["${gpu}"]=$((GPU_LOAD["${gpu}"] - 1))
+      local suite_name="${task_info%,*}"
       completed_tasks=$((completed_tasks + 1))
       if [[ "${status}" == "FAILED" ]]; then
         failed_tasks=$((failed_tasks + 1))
+        SUITE_COMPLETED_TASKS["${suite_name}"]=$((${SUITE_COMPLETED_TASKS[${suite_name}]:-0} + 1))
+        write_suite_success_rates_file
         echo "[manager] failed ${task_info}: ${status_line}" | tee -a "${OUTPUT_DIR}/failed_tasks.txt"
       else
-        local suite_name="${task_info%,*}"
         record_eval_result "${suite_name}" \
           "${OUTPUT_DIR}/${suite_name}/gpu${gpu}_task${task_info#*,}_results.json"
+        SUITE_COMPLETED_TASKS["${suite_name}"]=$((${SUITE_COMPLETED_TASKS[${suite_name}]:-0} + 1))
+        write_suite_success_rates_file
         local task_success_rate
         local suite_success_rate
         local overall_success_rate
@@ -693,6 +738,9 @@ poll_finished_tasks() {
       fi
       GPU_LOAD["${gpu}"]=$((GPU_LOAD["${gpu}"] - 1))
       completed_tasks=$((completed_tasks + 1))
+      local suite_name="${task_info%,*}"
+      SUITE_COMPLETED_TASKS["${suite_name}"]=$((${SUITE_COMPLETED_TASKS[${suite_name}]:-0} + 1))
+      write_suite_success_rates_file
       failed_tasks=$((failed_tasks + 1))
       echo "[manager] failed ${task_info}: child exited before writing status (rc=${rc}, log=${log_file})" \
         | tee -a "${OUTPUT_DIR}/failed_tasks.txt"
@@ -730,6 +778,7 @@ show_status() {
 
 write_gpu_load_file
 write_manager_config
+write_suite_success_rates_file
 
 echo "[manager] config=${CONFIG}"
 echo "[manager] ckpt=${ckpt_abs}"

--- a/test/test_datasets/test_dataset_wrapper.py
+++ b/test/test_datasets/test_dataset_wrapper.py
@@ -1,0 +1,203 @@
+# Copyright 2026 Limx Dynamics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+
+from fluxvla.datasets.dataset_wrapper import DistributedRepeatingDataset
+
+
+class TestDistributedRepeatingDatasetStatistics(unittest.TestCase):
+
+    def _make_wrapper(self, dim=None):
+        wrapper = DistributedRepeatingDataset.__new__(
+            DistributedRepeatingDataset)
+        wrapper.statistic_name = 'private'
+        wrapper.dim = dim
+        return wrapper
+
+    def test_combines_weighted_mean_and_std_with_scalar_counts(self):
+        wrapper = self._make_wrapper()
+        stats = [
+            {
+                'stats': {
+                    'action': {
+                        'min': [0.0, 8.0],
+                        'max': [2.0, 12.0],
+                        'mean': [1.0, 10.0],
+                        'std': [0.5, 1.0],
+                        'count': 2,
+                        'q01': [0.0, 8.0],
+                        'q99': [2.0, 12.0],
+                    }
+                }
+            },
+            {
+                'stats': {
+                    'action': {
+                        'min': [3.0, 11.0],
+                        'max': [7.0, 17.0],
+                        'mean': [5.0, 14.0],
+                        'std': [1.5, 2.0],
+                        'count': 6,
+                        'q01': [3.0, 11.0],
+                        'q99': [7.0, 17.0],
+                    }
+                }
+            },
+        ]
+
+        combined = wrapper.get_dataset_statistics(
+            stats, ['action'])['private']['action']
+
+        np.testing.assert_allclose(combined['mean'], [4.0, 13.0])
+        np.testing.assert_allclose(combined['std'], [np.sqrt(4.75), 2.5])
+        np.testing.assert_allclose(combined['q01'], [2.25, 10.25])
+        np.testing.assert_allclose(combined['q99'], [5.75, 15.75])
+
+    def test_unweighted_std_includes_between_dataset_variance(self):
+        wrapper = self._make_wrapper()
+        stats = [
+            {
+                'stats': {
+                    'action': {
+                        'min': [0.0],
+                        'max': [0.0],
+                        'mean': [0.0],
+                        'std': [0.0],
+                    }
+                }
+            },
+            {
+                'stats': {
+                    'action': {
+                        'min': [10.0],
+                        'max': [10.0],
+                        'mean': [10.0],
+                        'std': [0.0],
+                    }
+                }
+            },
+        ]
+
+        combined = wrapper.get_dataset_statistics(
+            stats, ['action'])['private']['action']
+
+        np.testing.assert_allclose(combined['mean'], [5.0])
+        np.testing.assert_allclose(combined['std'], [5.0])
+
+    def test_combines_weighted_mean_and_std_with_vector_counts(self):
+        wrapper = self._make_wrapper()
+        stats = [
+            {
+                'stats': {
+                    'action': {
+                        'min': [0.0, 10.0],
+                        'max': [0.0, 10.0],
+                        'mean': [0.0, 10.0],
+                        'std': [0.0, 0.0],
+                        'count': [1, 9],
+                    }
+                }
+            },
+            {
+                'stats': {
+                    'action': {
+                        'min': [10.0, 20.0],
+                        'max': [10.0, 20.0],
+                        'mean': [10.0, 20.0],
+                        'std': [0.0, 0.0],
+                        'count': [9, 1],
+                    }
+                }
+            },
+        ]
+
+        combined = wrapper.get_dataset_statistics(
+            stats, ['action'])['private']['action']
+
+        np.testing.assert_allclose(combined['mean'], [9.0, 11.0])
+        np.testing.assert_allclose(combined['std'], [3.0, 3.0])
+
+    def test_incomplete_counts_fall_back_to_unweighted_merge(self):
+        wrapper = self._make_wrapper()
+        stats = [
+            {
+                'stats': {
+                    'action': {
+                        'min': [0.0],
+                        'max': [0.0],
+                        'mean': [0.0],
+                        'std': [0.0],
+                        'count': 100,
+                    }
+                }
+            },
+            {
+                'stats': {
+                    'action': {
+                        'min': [10.0],
+                        'max': [10.0],
+                        'mean': [10.0],
+                        'std': [0.0],
+                    }
+                }
+            },
+        ]
+
+        combined = wrapper.get_dataset_statistics(
+            stats, ['action'])['private']['action']
+
+        np.testing.assert_allclose(combined['mean'], [5.0])
+        np.testing.assert_allclose(combined['std'], [5.0])
+
+    def test_padding_applies_to_quantiles_and_vector_counts(self):
+        wrapper = self._make_wrapper(dim=4)
+        stats = [
+            {
+                'stats': {
+                    'action': {
+                        'min': [0.0, 1.0, 2.0],
+                        'max': [0.0, 1.0, 2.0],
+                        'mean': [0.0, 1.0, 2.0],
+                        'std': [0.0, 0.0, 0.0],
+                        'count': [1, 1, 1],
+                        'q25': [0.0, 1.0, 2.0],
+                    }
+                }
+            },
+            {
+                'stats': {
+                    'action': {
+                        'min': [4.0, 5.0, 6.0],
+                        'max': [4.0, 5.0, 6.0],
+                        'mean': [4.0, 5.0, 6.0],
+                        'std': [0.0, 0.0, 0.0],
+                        'count': [3, 3, 3],
+                        'q25': [4.0, 5.0, 6.0],
+                    }
+                }
+            },
+        ]
+
+        combined = wrapper.get_dataset_statistics(
+            stats, ['action'])['private']['action']
+
+        np.testing.assert_allclose(combined['mean'], [3.0, 4.0, 5.0, 3.0])
+        np.testing.assert_allclose(combined['q25'], [3.0, 4.0, 5.0, 3.0])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- Make `eval_libero_manager.sh` resolve output directories as:
  terminal `OUTPUT_DIR` > config `eval.manager.output_dir` > config `eval.runner.result_output_dir` > timestamped `work_dirs` fallback.
- Add live `suite_success_rates.csv` output for manager runs.
- Show global real-time LIBERO eval success rate across ranks instead of rank0-only progress.
- Stop printing rollout video save paths to stdout while preserving them in per-task log files.
