### PR TITLE
Fix : adjust action chunk dimension

### DIFF
--- a/fluxvla/engines/runners/serving/zmq_server.py
+++ b/fluxvla/engines/runners/serving/zmq_server.py
@@ -243,7 +243,7 @@ def create_server(
             actions_np = actions.cpu().numpy()
             d = denormalize_action(
                 dict(action=actions_np, task_suite_name=task_suite_name))
-            actions = torch.from_numpy(d[None].astype(np.float32))
+            actions = torch.from_numpy(d.astype(np.float32))
 
         action_bytes = serialize_actions(actions)
 

--- a/fluxvla/engines/runners/serving/zmq_server.py
+++ b/fluxvla/engines/runners/serving/zmq_server.py
@@ -242,7 +242,7 @@ def create_server(
         if denormalize_action is not None:
             actions_np = actions.cpu().numpy()
             d = denormalize_action(
-                dict(action=actions_np[0], task_suite_name=task_suite_name))
+                dict(action=actions_np, task_suite_name=task_suite_name))
             actions = torch.from_numpy(d[None].astype(np.float32))
 
         action_bytes = serialize_actions(actions)


### PR DESCRIPTION
The previous PR test on real robot UR3 using MoveL control mode, which tracks one target point causing action chunk dimension mismatch in normal cases.