### PR TITLE
[Hotfix]: Fix config settings

### DIFF
--- a/configs/gr00t/gr00t_eagle_3b_robocasa_finetune.py
+++ b/configs/gr00t/gr00t_eagle_3b_robocasa_finetune.py
@@ -153,7 +153,6 @@ runner = dict(
     save_iter_interval=500,
     save_epoch_interval=1,
     max_keep_ckpts=5,
-    save_full_model=True,
     tokenizer=dict(
         type='PretrainedTokenizer',
         model_path='fluxvla/models/third_party_models/eagle2_hg_model'),

--- a/configs/pi0/pi0_paligemma_aloha+ur_full_finetune.py
+++ b/configs/pi0/pi0_paligemma_aloha+ur_full_finetune.py
@@ -251,7 +251,6 @@ train_dataloader = dict(
 
 runner = dict(
     type='FSDPTrainRunner',
-    stage='vla-full-train',
     max_epochs=5,
     optimizer=dict(lr=2e-5, type='AdamW', weight_decay=0.0),
     max_grad_norm=1.0,

--- a/configs/pi0/pi0_paligemma_aloha_full_finetune.py
+++ b/configs/pi0/pi0_paligemma_aloha_full_finetune.py
@@ -195,7 +195,6 @@ train_dataloader = dict(
 
 runner = dict(
     type='FSDPTrainRunner',
-    stage='vla-full-train',
     max_epochs=3,
     optimizer=dict(lr=2e-5, type='AdamW', weight_decay=0.0),
     max_grad_norm=1.0,

--- a/configs/pi0/pi0_paligemma_ur3_full_finetune.py
+++ b/configs/pi0/pi0_paligemma_ur3_full_finetune.py
@@ -187,7 +187,6 @@ train_dataloader = dict(
 
 runner = dict(
     type='FSDPTrainRunner',
-    stage='vla-full-train',
     max_epochs=3,
     optimizer=dict(lr=2e-5, type='AdamW', weight_decay=0.0),
     max_grad_norm=1.0,

--- a/configs/pi05/pi05_paligemma_franka_dual_eepose_full_finetune.py
+++ b/configs/pi05/pi05_paligemma_franka_dual_eepose_full_finetune.py
@@ -182,8 +182,7 @@ train_dataloader = dict(
 runner = dict(
     type='FSDPTrainRunner',
     max_epochs=6,
-    learning_rate=5e-5,
-    weight_decay=0.01,
+    optimizer=dict(lr=5e-5, type='AdamW', weight_decay=0.01),
     max_grad_norm=1.0,
     sharding_strategy='no-shard',
     collator=dict(
@@ -194,7 +193,6 @@ runner = dict(
         ],
         meta_keys=['task_description', 'prompt', 'info', 'stats']),
     sampler=None,
-    warmup_ratio=0.03,
     tokenizer=dict(
         type='PretrainedTokenizer',
         model_path=  # noqa: E251
@@ -207,7 +205,10 @@ runner = dict(
         run_dir='work_dirs',
         grad_accumulation_steps=1,
         window_size=1),
-    lr_scheduler_type='linear-warmup+cosine-decay',
+    lr_scheduler=dict(
+        type='linear-warmup+cosine-decay',
+        warmup_ratio=0.03,
+    ),
     enable_gradient_checkpointing=False,
     enable_mixed_precision_training=True,
     mixed_precision_dtype='bf16',

--- a/configs/pi05/pi05_paligemma_franka_dual_qpos_full_finetune.py
+++ b/configs/pi05/pi05_paligemma_franka_dual_qpos_full_finetune.py
@@ -182,8 +182,7 @@ train_dataloader = dict(
 runner = dict(
     type='FSDPTrainRunner',
     max_epochs=6,
-    learning_rate=5e-5,
-    weight_decay=0.01,
+    optimizer=dict(lr=5e-5, type='AdamW', weight_decay=0.01),
     max_grad_norm=1.0,
     sharding_strategy='no-shard',
     collator=dict(
@@ -194,7 +193,6 @@ runner = dict(
         ],
         meta_keys=['task_description', 'prompt', 'info', 'stats']),
     sampler=None,
-    warmup_ratio=0.03,
     tokenizer=dict(
         type='PretrainedTokenizer',
         model_path=  # noqa: E251
@@ -207,7 +205,10 @@ runner = dict(
         run_dir='work_dirs',
         grad_accumulation_steps=1,
         window_size=1),
-    lr_scheduler_type='linear-warmup+cosine-decay',
+    lr_scheduler=dict(
+        type='linear-warmup+cosine-decay',
+        warmup_ratio=0.03,
+    ),
     enable_gradient_checkpointing=False,
     enable_mixed_precision_training=True,
     mixed_precision_dtype='bf16',

--- a/configs/pi05/pi05_paligemma_franka_single_qpos_inference.py
+++ b/configs/pi05/pi05_paligemma_franka_single_qpos_inference.py
@@ -189,8 +189,7 @@ train_dataloader = dict(
 runner = dict(
     type='FSDPTrainRunner',
     max_epochs=6,
-    learning_rate=5e-5,
-    weight_decay=0.01,
+    optimizer=dict(lr=5e-5, type='AdamW', weight_decay=0.01),
     max_grad_norm=1.0,
     sharding_strategy='no-shard',
     collator=dict(
@@ -201,7 +200,6 @@ runner = dict(
         ],
         meta_keys=['task_description', 'prompt', 'info', 'stats']),
     sampler=None,
-    warmup_ratio=0.03,
     tokenizer=dict(
         type='PretrainedTokenizer',
         model_path='checkpoints/pi05_base',
@@ -212,7 +210,10 @@ runner = dict(
         run_dir='work_dirs',
         grad_accumulation_steps=1,
         window_size=1),
-    lr_scheduler_type='linear-warmup+cosine-decay',
+    lr_scheduler=dict(
+        type='linear-warmup+cosine-decay',
+        warmup_ratio=0.03,
+    ),
     enable_gradient_checkpointing=False,
     enable_mixed_precision_training=True,
     mixed_precision_dtype='bf16',

--- a/configs/pi05/pi05_paligemma_libero_10_lora_finetune.py
+++ b/configs/pi05/pi05_paligemma_libero_10_lora_finetune.py
@@ -205,7 +205,6 @@ runner = dict(
     max_epochs=24,
     optimizer=dict(lr=5e-5, type='AdamW', weight_decay=0.0),
     max_grad_norm=1.0,
-    sharding_strategy='no-shard',
     collator=dict(
         type='DictCollator',
         keys=[
@@ -229,8 +228,7 @@ runner = dict(
     ),
     enable_gradient_checkpointing=True,
     enable_mixed_precision_training=True,
-    mixed_precision_dtype='bf16',
-    change_key_name=False)
+    mixed_precision_dtype='bf16')
 
 eval = dict(
     type='LiberoEvalRunner',


### PR DESCRIPTION
## Summary

Fix stale runner config fields so training configs remain compatible with the current `FSDPTrainRunner` / `DDPTrainRunner` constructor validation.

## Changes

- Remove deprecated `save_full_model` from the GR00T RoboCasa FSDP config.
- Remove obsolete `stage='vla-full-train'` from Pi0 FSDP configs.
- Migrate Pi0.5 Franka configs from legacy optimizer fields:
  - `learning_rate`
  - `weight_decay`
  - `lr_scheduler_type`
  - top-level `warmup_ratio`
  
  to the current `optimizer=dict(...)` and `lr_scheduler=dict(...)` format.
- Remove FSDP-only fields from the Pi0.5 LIBERO LoRA DDP config:
  - `sharding_strategy`
  - `change_key_name`

## Why

Recent runner refactoring added strict validation for unexpected runner fields. Some configs still used older field names or runner-specific options, causing errors such as:

```text
TypeError: Unexpected runner config field(s): save_full_model