### PR TITLE
[Feat]: Support fluxthemis

### DIFF
--- a/configs/gr00t/gr00t_eagle_3b_robocasa_30_eps_full_finetune.py
+++ b/configs/gr00t/gr00t_eagle_3b_robocasa_30_eps_full_finetune.py
@@ -211,15 +211,20 @@ inference_model = dict(
 
 eval = dict(
     type='RobocasaEvalRunner',
+    benchmark='robocasa',
+    task_suite_name='robocasa',
     model_family='groot',
     task_list=[
         f'gr1_unified/{task_dir}_GR1ArmsAndWaistFourierHands_Env'
         for task_dir in _ROBOCASA_TASK_DIRS
     ],
+    total_tasks=24,
     eval_chunk_size=16,
     max_episode_steps=720,
+    num_trials_per_task=50,
     seed=7,
     unnorm_key=_STAT,
+    action_order='n15',
     dataset=dict(
         type='RobocasaEvalDataset',
         unnorm_key=_STAT,
@@ -259,4 +264,63 @@ eval = dict(
         action_dim=29,
         clip_actions=False,
         stats_order='fluxvla'),
+)
+
+themis = dict(
+    transport=dict(
+        service_name='/fluxvla/predict_action',
+        report_service_name='/fluxvla/report_evaluation',
+        timeout_s=30.0,
+        image_keys=['video.ego_view_bg_crop_pad_res256_freq20'],
+        state_keys=[
+            'state.left_arm',
+            'state.left_hand',
+            'state.right_arm',
+            'state.right_hand',
+            'state.waist',
+        ],
+        unnorm_key=_STAT,
+        image_encoding='rgb8',
+    ),
+    runner=dict(
+        type='EvalRunner',
+        environment=dict(
+            type='RoboCasaEnvironment',
+            task_list=eval['task_list'],
+            action_order=eval['action_order'],
+            deterministic_env=True,
+            prompt_key='annotation.human.coarse_action',
+            render_key='video.ego_view_pad_res256_freq20',
+        ),
+        model_client=dict(type='FluxVLAROSModelClient'),
+        evaluator=dict(type='SuccessRateEvaluator'),
+        seed=eval['seed'],
+        episodes_per_task=eval['num_trials_per_task'],
+        max_episode_steps=eval['max_episode_steps'],
+        execute_horizon=eval['eval_chunk_size'],
+        stop_on_success=True,
+        parallel_workers=1,
+        simulator_gpu_ids=None,
+        work_dir='work_dirs/fluxthemis',
+    ),
+    ros_server=dict(
+        ros_version=1,
+        dataset_section='eval',
+        evaluation_reporting=dict(
+            result_output_dir='work_dirs/fluxthemis',
+            report_kind='robocasa',
+        ),
+        device='cuda:0',
+        workers=dict(
+            startup_timeout_s=900.0,
+            request_timeout_s=120.0,
+            lease_timeout_s=900.0,
+        ),
+        mixed_precision_dtype='bf16',
+        enable_mixed_precision=True,
+        model_outputs_environment_actions=False,
+        forward_seed=False,
+        denormalize_context={},
+        denormalize_per_action=True,
+    ),
 )

--- a/configs/pi05/pi05_paligemma_libero_10_full_finetune.py
+++ b/configs/pi05/pi05_paligemma_libero_10_full_finetune.py
@@ -251,3 +251,48 @@ eval = dict(
         action_dim=7,
     ),
 )
+
+themis = dict(
+    transport=dict(
+        service_name='/fluxvla/predict_action',
+        timeout_s=30.0,
+        image_keys=['agentview_image', 'robot0_eye_in_hand_image'],
+        state_keys=[
+            'robot0_eef_pos',
+            'robot0_eef_quat',
+            'robot0_gripper_qpos',
+        ],
+        unnorm_key='libero_10_no_noops',
+        image_encoding='rgb8',
+    ),
+    runner=dict(
+        type='EvalRunner',
+        environment=dict(
+            type='LiberoEnvironment',
+            task_suite_name='libero_10',
+            task_order_index=0,
+            resolution=256,
+            controller='OSC_POSE',
+            simulator_seed=0,
+            num_steps_wait=10,
+        ),
+        model_client=dict(type='FluxVLAROSModelClient'),
+        evaluator=dict(type='SuccessRateEvaluator'),
+        seed=7,
+        episodes_per_task=50,
+        max_episode_steps=520,
+        execute_horizon=10,
+        stop_on_success=True,
+        work_dir='work_dirs/fluxthemis',
+    ),
+    ros_server=dict(
+        ros_version=1,
+        dataset_section='eval',
+        device='cuda:0',
+        mixed_precision_dtype='bf16',
+        enable_mixed_precision=True,
+        model_outputs_environment_actions=False,
+        forward_seed=False,
+        denormalize_context={},
+    ),
+)

--- a/configs/pi05/pi05_paligemma_libero_10_full_finetune.py
+++ b/configs/pi05/pi05_paligemma_libero_10_full_finetune.py
@@ -284,6 +284,8 @@ themis = dict(
         max_episode_steps=520,
         execute_horizon=10,
         stop_on_success=True,
+        parallel_workers=1,
+        simulator_gpu_ids=None,
         work_dir='work_dirs/fluxthemis',
     ),
     ros_server=dict(
@@ -291,6 +293,11 @@ themis = dict(
         dataset_section='eval',
         evaluation_reporting=dict(result_output_dir='work_dirs/fluxthemis', ),
         device='cuda:0',
+        workers=dict(
+            startup_timeout_s=900.0,
+            request_timeout_s=120.0,
+            lease_timeout_s=900.0,
+        ),
         mixed_precision_dtype='bf16',
         enable_mixed_precision=True,
         model_outputs_environment_actions=False,

--- a/configs/pi05/pi05_paligemma_libero_10_full_finetune.py
+++ b/configs/pi05/pi05_paligemma_libero_10_full_finetune.py
@@ -255,6 +255,7 @@ eval = dict(
 themis = dict(
     transport=dict(
         service_name='/fluxvla/predict_action',
+        report_service_name='/fluxvla/report_evaluation',
         timeout_s=30.0,
         image_keys=['agentview_image', 'robot0_eye_in_hand_image'],
         state_keys=[
@@ -288,6 +289,7 @@ themis = dict(
     ros_server=dict(
         ros_version=1,
         dataset_section='eval',
+        evaluation_reporting=dict(result_output_dir='work_dirs/fluxthemis', ),
         device='cuda:0',
         mixed_precision_dtype='bf16',
         enable_mixed_precision=True,

--- a/configs/pi05/pi05_paligemma_robocasa_30_eps_full_finetune.py
+++ b/configs/pi05/pi05_paligemma_robocasa_30_eps_full_finetune.py
@@ -347,6 +347,8 @@ runner = dict(
 # unnorm_key must match the training statistic_name.
 eval = dict(
     type='RobocasaEvalRunner',
+    benchmark='robocasa',
+    task_suite_name='robocasa',
     model_family='pi0',
     task_list=[
         _robocasa_task_env('PnPBottleToCabinetClose'),
@@ -387,6 +389,7 @@ eval = dict(
         _robocasa_task_env('PosttrainPnPNovelFromTray'
                            'ToTieredshelfSplitA'),
     ],
+    total_tasks=24,
     # Match the 16-step training horizon and the historical best evaluation.
     eval_chunk_size=16,
     max_episode_steps=720,
@@ -432,5 +435,64 @@ eval = dict(
         action_dim=29,
         clip_actions=False,
         stats_order='native',
+    ),
+)
+
+themis = dict(
+    transport=dict(
+        service_name='/fluxvla/predict_action',
+        report_service_name='/fluxvla/report_evaluation',
+        timeout_s=30.0,
+        image_keys=['video.ego_view_bg_crop_pad_res256_freq20'],
+        state_keys=[
+            'state.left_arm',
+            'state.left_hand',
+            'state.right_arm',
+            'state.right_hand',
+            'state.waist',
+        ],
+        unnorm_key=_ROBOCASA_STATISTIC_NAME,
+        image_encoding='rgb8',
+    ),
+    runner=dict(
+        type='EvalRunner',
+        environment=dict(
+            type='RoboCasaEnvironment',
+            task_list=eval['task_list'],
+            action_order=eval['action_order'],
+            deterministic_env=True,
+            prompt_key='annotation.human.coarse_action',
+            render_key='video.ego_view_pad_res256_freq20',
+        ),
+        model_client=dict(type='FluxVLAROSModelClient'),
+        evaluator=dict(type='SuccessRateEvaluator'),
+        seed=eval['seed'],
+        episodes_per_task=eval['num_trials_per_task'],
+        max_episode_steps=eval['max_episode_steps'],
+        execute_horizon=eval['eval_chunk_size'],
+        stop_on_success=True,
+        parallel_workers=1,
+        simulator_gpu_ids=None,
+        work_dir='work_dirs/fluxthemis',
+    ),
+    ros_server=dict(
+        ros_version=1,
+        dataset_section='eval',
+        evaluation_reporting=dict(
+            result_output_dir='work_dirs/fluxthemis',
+            report_kind='robocasa',
+        ),
+        device='cuda:0',
+        workers=dict(
+            startup_timeout_s=900.0,
+            request_timeout_s=120.0,
+            lease_timeout_s=900.0,
+        ),
+        mixed_precision_dtype='bf16',
+        enable_mixed_precision=True,
+        model_outputs_environment_actions=False,
+        forward_seed=False,
+        denormalize_context={},
+        denormalize_per_action=True,
     ),
 )

--- a/configs/pi05/pi05_paligemma_robocasa_full_data_full_finetune.py
+++ b/configs/pi05/pi05_paligemma_robocasa_full_data_full_finetune.py
@@ -369,6 +369,8 @@ runner = dict(
 # unnorm_key must match the training statistic_name.
 eval = dict(
     type='RobocasaEvalRunner',
+    benchmark='robocasa',
+    task_suite_name='robocasa',
     model_family='pi0',
     task_list=[
         _robocasa_task_env('PnPBottleToCabinetClose'),
@@ -409,6 +411,7 @@ eval = dict(
         _robocasa_task_env('PosttrainPnPNovelFromTray'
                            'ToTieredshelfSplitA'),
     ],
+    total_tasks=24,
     # Keep the 16-step prediction horizon, but replan halfway through it.
     # At 20 Hz this reduces open-loop execution from 0.8 s to 0.4 s without
     # changing the positive 100k-step training recipe.
@@ -456,5 +459,64 @@ eval = dict(
         action_dim=29,
         clip_actions=False,
         stats_order='native',
+    ),
+)
+
+themis = dict(
+    transport=dict(
+        service_name='/fluxvla/predict_action',
+        report_service_name='/fluxvla/report_evaluation',
+        timeout_s=30.0,
+        image_keys=['video.ego_view_bg_crop_pad_res256_freq20'],
+        state_keys=[
+            'state.left_arm',
+            'state.left_hand',
+            'state.right_arm',
+            'state.right_hand',
+            'state.waist',
+        ],
+        unnorm_key=_ROBOCASA_STATISTIC_NAME,
+        image_encoding='rgb8',
+    ),
+    runner=dict(
+        type='EvalRunner',
+        environment=dict(
+            type='RoboCasaEnvironment',
+            task_list=eval['task_list'],
+            action_order=eval['action_order'],
+            deterministic_env=True,
+            prompt_key='annotation.human.coarse_action',
+            render_key='video.ego_view_pad_res256_freq20',
+        ),
+        model_client=dict(type='FluxVLAROSModelClient'),
+        evaluator=dict(type='SuccessRateEvaluator'),
+        seed=eval['seed'],
+        episodes_per_task=eval['num_trials_per_task'],
+        max_episode_steps=eval['max_episode_steps'],
+        execute_horizon=eval['eval_chunk_size'],
+        stop_on_success=True,
+        parallel_workers=1,
+        simulator_gpu_ids=None,
+        work_dir='work_dirs/fluxthemis',
+    ),
+    ros_server=dict(
+        ros_version=1,
+        dataset_section='eval',
+        evaluation_reporting=dict(
+            result_output_dir='work_dirs/fluxthemis',
+            report_kind='robocasa',
+        ),
+        device='cuda:0',
+        workers=dict(
+            startup_timeout_s=900.0,
+            request_timeout_s=120.0,
+            lease_timeout_s=900.0,
+        ),
+        mixed_precision_dtype='bf16',
+        enable_mixed_precision=True,
+        model_outputs_environment_actions=False,
+        forward_seed=False,
+        denormalize_context={},
+        denormalize_per_action=True,
     ),
 )

--- a/docs/feishu_eval_reporting.md
+++ b/docs/feishu_eval_reporting.md
@@ -12,11 +12,70 @@ This feature works with:
 - `scripts/train.py --eval-after-train`
 - `scripts/train.sh ... --eval-after-train`
 - `tools/summarize_libero_eval_results.py`
+- `scripts/ros_inference_server.py` with FluxThemis `ReportEvaluation`
+
+## FluxThemis ROS Evaluation Reporting
+
+An integrated ROS evaluation can make FluxVLA the authoritative result owner
+without changing the usual two-terminal launch commands. Configure the shared
+target model file as follows:
+
+```python
+themis = dict(
+    transport=dict(
+        service_name='/fluxvla/predict_action',
+        report_service_name='/fluxvla/report_evaluation',
+        # observation and transport fields ...
+    ),
+    ros_server=dict(
+        evaluation_reporting=dict(
+            result_output_dir='work_dirs/fluxthemis',
+            # Optional direct overrides; otherwise use the environment below.
+            feishu=dict(),
+        ),
+        # inference fields ...
+    ),
+    # runner ...
+)
+```
+
+`report_service_name` enables the acknowledged lifecycle channel. Omitting it
+keeps the PredictAction-only server compatible with older/local clients.
+`result_output_dir` defaults to `work_dirs/fluxthemis`, resolves relative to the
+FluxVLA repository, and must remain inside its `work_dirs` tree.
+
+For every accepted run, the server writes FluxVLA's native layout:
+
+```text
+<result_output_dir>/eval_runs/<checkpoint_stem>/
+  EVAL-<suite>-<model_family>-YYYY_MM_DD-HH_MM_SS[-<run_name>]/
+```
+
+The directory contains `events.jsonl`, `rank0.txt`, and
+`rank_progress/rank0.json` during rollout. At `run_end`, it also contains the
+suite's `<suite>/task<task_index>_results.json` and
+`task_status/<suite>_task<task_index>.status` files plus `failed_tasks.txt`,
+`summary.txt`, `summary.csv`, `summary.json`, and `task_success_rates.csv`.
+`[ros-eval]` and `[eval-progress]` messages, the final directory, and Feishu
+report/skip reasons appear in the FluxVLA server terminal.
+
+The `evaluation_reporting.feishu` mapping accepts `sheet_url`, `app_id`,
+`app_secret`, and `timeout`. Missing values use `FEISHU_SHEET_URL`,
+`FEISHU_APP_ID`, and `FEISHU_APP_SECRET` from the server process. `timeout`
+defaults to 10 seconds for this ROS path. Prefer the environment variables for
+credentials so secrets stay out of configuration snapshots and event journals.
+
+ROS-triggered upload is intentionally full-suite-only. The terminal `run_end`
+must be `finished`, no task filter may be present, the numeric task set must
+match the authoritative suite manifest, and every task must have exactly the
+configured number of completed trials. Smoke, filtered, partial, interrupted,
+and failed runs keep their native files but do not append a spreadsheet row.
 
 ## What Gets Written
 
-The reporter writes one row per completed evaluation summary. It does not
-deduplicate rows, so running the same command twice appends two rows.
+For an evaluation that passes the applicable reporting gate, the reporter writes
+one row per completed summary. It does not deduplicate rows, so running the same
+command twice appends two rows.
 
 LIBERO uses this header:
 

--- a/docs/feishu_eval_reporting.md
+++ b/docs/feishu_eval_reporting.md
@@ -12,7 +12,7 @@ This feature works with:
 - `scripts/train.py --eval-after-train`
 - `scripts/train.sh ... --eval-after-train`
 - `tools/summarize_libero_eval_results.py`
-- `scripts/ros_inference_server.py` with FluxThemis `ReportEvaluation`
+- `scripts/ros_inference_server.sh` with FluxThemis `ReportEvaluation`
 
 ## FluxThemis ROS Evaluation Reporting
 

--- a/fluxvla/engines/runners/serving/__init__.py
+++ b/fluxvla/engines/runners/serving/__init__.py
@@ -27,6 +27,10 @@ def __getattr__(name):
         'build_ros_server_from_config',
     }
     _ros2_server = {'FluxVLAROS2Server'}
+    _evaluation_reporter = {
+        'EvaluationEventError',
+        'FluxVLAROSEvaluationReporter',
+    }
 
     if name in _public:
         from . import serializers
@@ -40,13 +44,18 @@ def __getattr__(name):
     if name in _ros2_server:
         from . import ros2_server
         return getattr(ros2_server, name)
+    if name in _evaluation_reporter:
+        from . import evaluation_reporter
+        return getattr(evaluation_reporter, name)
     raise AttributeError(f'module {__name__!r} has no attribute {name!r}')
 
 
 __all__ = [
     'FORMAT_MSGPACK',
     'FORMAT_PROTOBUF',
+    'EvaluationEventError',
     'FluxVLAROSPolicy',
+    'FluxVLAROSEvaluationReporter',
     'FluxVLAROS2Server',
     'FluxVLAROSServer',
     'MsgSerializer',

--- a/fluxvla/engines/runners/serving/__init__.py
+++ b/fluxvla/engines/runners/serving/__init__.py
@@ -21,6 +21,12 @@ def __getattr__(name):
         'encode_predict_response',
     }
     _server = {'PolicyServer', 'create_server', 'serialize_actions'}
+    _ros_server = {
+        'FluxVLAROSPolicy',
+        'FluxVLAROSServer',
+        'build_ros_server_from_config',
+    }
+    _ros2_server = {'FluxVLAROS2Server'}
 
     if name in _public:
         from . import serializers
@@ -28,17 +34,27 @@ def __getattr__(name):
     if name in _server:
         from . import zmq_server
         return getattr(zmq_server, name)
+    if name in _ros_server:
+        from . import ros_server
+        return getattr(ros_server, name)
+    if name in _ros2_server:
+        from . import ros2_server
+        return getattr(ros2_server, name)
     raise AttributeError(f'module {__name__!r} has no attribute {name!r}')
 
 
 __all__ = [
     'FORMAT_MSGPACK',
     'FORMAT_PROTOBUF',
+    'FluxVLAROSPolicy',
+    'FluxVLAROS2Server',
+    'FluxVLAROSServer',
     'MsgSerializer',
     'ObsSerializer',
     'ObsSerializerProto',
     'PolicyServer',
     'create_server',
+    'build_ros_server_from_config',
     'decode_predict_request',
     'decode_predict_response',
     'detect_format',

--- a/fluxvla/engines/runners/serving/__init__.py
+++ b/fluxvla/engines/runners/serving/__init__.py
@@ -24,9 +24,14 @@ def __getattr__(name):
     _ros_server = {
         'FluxVLAROSPolicy',
         'FluxVLAROSServer',
+        'build_ros_policy_from_config',
         'build_ros_server_from_config',
     }
     _ros2_server = {'FluxVLAROS2Server'}
+    _ros_worker_pool = {
+        'EpisodeAffinityPolicyPool',
+        'spawn_ros_policy_pool',
+    }
     _evaluation_reporter = {
         'EvaluationEventError',
         'FluxVLAROSEvaluationReporter',
@@ -44,6 +49,9 @@ def __getattr__(name):
     if name in _ros2_server:
         from . import ros2_server
         return getattr(ros2_server, name)
+    if name in _ros_worker_pool:
+        from . import ros_worker_pool
+        return getattr(ros_worker_pool, name)
     if name in _evaluation_reporter:
         from . import evaluation_reporter
         return getattr(evaluation_reporter, name)
@@ -58,11 +66,13 @@ __all__ = [
     'FluxVLAROSEvaluationReporter',
     'FluxVLAROS2Server',
     'FluxVLAROSServer',
+    'EpisodeAffinityPolicyPool',
     'MsgSerializer',
     'ObsSerializer',
     'ObsSerializerProto',
     'PolicyServer',
     'create_server',
+    'build_ros_policy_from_config',
     'build_ros_server_from_config',
     'decode_predict_request',
     'decode_predict_response',
@@ -70,4 +80,5 @@ __all__ = [
     'encode_predict_request',
     'encode_predict_response',
     'serialize_actions',
+    'spawn_ros_policy_pool',
 ]

--- a/fluxvla/engines/runners/serving/evaluation_reporter.py
+++ b/fluxvla/engines/runners/serving/evaluation_reporter.py
@@ -1,0 +1,962 @@
+"""Durable ROS evaluation events and native FluxVLA LIBERO artifacts.
+
+``FluxVLAROSEvaluationReporter`` is the small adapter boundary used by ROS 1
+and ROS 2 servers.  A server passes versioned ``run_start``,
+``episode_start``, ``episode_end`` and ``run_end`` events to
+``process_event``.  The reporter validates ordering and idempotency, journals
+accepted events, maintains native live progress, and writes the same result
+schema as :class:`LiberoEvalRunner`.
+
+The class deliberately has no ROS dependency.  Server adapters may construct
+it before ROS initialization and later replace the default Overwatch logger
+with :meth:`set_logger`.
+"""
+from __future__ import annotations
+import copy
+import csv
+import json
+import math
+import os
+import threading
+import time
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Optional
+
+from fluxvla.engines.utils import initialize_overwatch
+from fluxvla.engines.utils.feishu_reporter import \
+    maybe_report_summary_to_feishu
+
+overwatch = initialize_overwatch(__name__)
+
+EVENT_VERSION = 1
+RUN_SCHEMA_VERSION = '1.0'
+EVENT_TYPES = frozenset(
+    {'run_start', 'episode_start', 'episode_end', 'run_end'})
+LIBERO_SUITE_TASK_COUNTS = {
+    'libero_spatial': 10,
+    'libero_object': 10,
+    'libero_goal': 10,
+    'libero_10': 10,
+    'libero_90': 90,
+}
+
+
+class EvaluationEventError(ValueError):
+    """A rejected ROS evaluation event."""
+
+
+@dataclass(frozen=True)
+class _TaskManifestEntry:
+    task_id: str
+    task_index: int
+    description: str
+    metadata: dict
+
+
+@dataclass
+class _RunState:
+    session_id: str
+    run_id: str
+    run_dir: Path
+    start: dict
+    tasks_by_id: dict[str, _TaskManifestEntry]
+    tasks_by_index: dict[int, _TaskManifestEntry]
+    next_sequence: int = 2
+    current_episode: Optional[dict] = None
+    episodes: list[dict] = field(default_factory=list)
+    completed_keys: set[tuple[int, int]] = field(default_factory=set)
+
+
+@dataclass(frozen=True)
+class _CachedRequest:
+    fingerprint: str
+    response: dict
+
+
+def _cfg_get(config, key: str, default=None):
+    if isinstance(config, Mapping):
+        return config.get(key, default)
+    return getattr(config, key, default)
+
+
+def _runner_eval_config(config):
+    runner = _cfg_get(config, 'runner')
+    if runner is None:
+        return config
+    if isinstance(config, Mapping) and isinstance(runner, Mapping):
+        # Some configs wrap runner-native fields in ``eval.runner`` while the
+        # ROS server adds authoritative task overrides at ``eval`` level.
+        # Preserve both, with the outer values taking precedence.
+        merged = dict(runner)
+        merged.update(
+            {key: value
+             for key, value in config.items() if key != 'runner'})
+        return merged
+    return runner
+
+
+def _require_mapping(value, name: str) -> dict:
+    if not isinstance(value, Mapping):
+        raise EvaluationEventError(f'{name} must be a mapping')
+    try:
+        return json.loads(json.dumps(dict(value), ensure_ascii=False))
+    except (TypeError, ValueError) as exc:
+        message = f'{name} must be JSON serializable: {exc}'
+        raise EvaluationEventError(message) from exc
+
+
+def _require_string(value, name: str, allow_empty: bool = False) -> str:
+    if not isinstance(value, str):
+        raise EvaluationEventError(f'{name} must be a string')
+    value = value.strip()
+    if not value and not allow_empty:
+        raise EvaluationEventError(f'{name} cannot be empty')
+    return value
+
+
+def _require_int(value, name: str, minimum: Optional[int] = None) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise EvaluationEventError(f'{name} must be an integer')
+    if minimum is not None and value < minimum:
+        raise EvaluationEventError(f'{name} must be >= {minimum}')
+    return value
+
+
+def _require_number(value,
+                    name: str,
+                    minimum: Optional[float] = None) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise EvaluationEventError(f'{name} must be a number')
+    value = float(value)
+    if not math.isfinite(value):
+        raise EvaluationEventError(f'{name} must be finite')
+    if minimum is not None and value < minimum:
+        raise EvaluationEventError(f'{name} must be >= {minimum}')
+    return value
+
+
+def _require_bool(value, name: str) -> bool:
+    if not isinstance(value, bool):
+        raise EvaluationEventError(f'{name} must be a boolean')
+    return value
+
+
+def _require_datetime(value, name: str) -> tuple[str, float]:
+    value = _require_string(value, name)
+    normalized = value[:-1] + '+00:00' if value.endswith('Z') else value
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise EvaluationEventError(f'{name} must be an ISO-8601 timestamp') \
+            from exc
+    return value, parsed.timestamp()
+
+
+def _format_duration(seconds: float) -> str:
+    seconds = int(round(seconds))
+    if seconds < 60:
+        return f'{seconds:02d}s'
+    if seconds < 3600:
+        return f'{seconds // 60:02d}m{seconds % 60:02d}s'
+    hours, remainder = divmod(seconds, 3600)
+    return f'{hours:02d}h{remainder // 60:02d}m{remainder % 60:02d}s'
+
+
+def _write_json_atomic(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f'{path.name}.tmp')
+    with temporary.open('w', encoding='utf-8') as stream:
+        json.dump(value, stream, indent=4, ensure_ascii=False)
+        stream.flush()
+        os.fsync(stream.fileno())
+    os.replace(temporary, path)
+
+
+class FluxVLAROSEvaluationReporter:
+    """Consume ROS evaluation lifecycle events and write native artifacts.
+
+    Args:
+        result_root: Result root. It is resolved to an absolute path;
+            individual runs are placed below ``eval_runs/<checkpoint stem>``.
+        config_path: Authoritative FluxVLA MMEngine config path.
+        ckpt_path: Authoritative model checkpoint path.
+        eval_config: The selected FluxVLA eval runner config. At minimum it
+            must define ``task_suite_name``, ``model_family`` and
+            ``num_trials_per_task``.
+        logger: Optional ``Callable[[str], None]``. Defaults to Overwatch.
+        feishu: Optional mapping with ``sheet_url``, ``app_id``, ``app_secret``
+            and ``timeout``. Missing credentials retain the native environment
+            variable fallback.
+
+    ``process_event`` returns a response dict containing ``accepted``,
+    ``error``, ``run_dir``, ``duplicate``, ``next_sequence`` and ``status``.
+    Protocol validation failures are returned in-band rather than raised. The
+    first event of every run has sequence ``1``.
+    """
+
+    def __init__(self,
+                 result_root,
+                 config_path,
+                 ckpt_path,
+                 eval_config,
+                 logger=None,
+                 feishu=None):
+        self.result_root = Path(result_root).expanduser().resolve()
+        self.config_path = str(Path(config_path).expanduser().resolve())
+        self.ckpt_path = str(Path(ckpt_path).expanduser().resolve())
+        self.eval_config = _runner_eval_config(eval_config)
+        self.task_suite_name = _require_string(
+            _cfg_get(self.eval_config, 'task_suite_name'),
+            'eval_config.task_suite_name')
+        self.model_family = _require_string(
+            _cfg_get(self.eval_config, 'model_family'),
+            'eval_config.model_family')
+        self.num_trials_per_task = _require_int(
+            _cfg_get(self.eval_config, 'num_trials_per_task'),
+            'eval_config.num_trials_per_task', 1)
+        self.configured_task_ids = _cfg_get(self.eval_config, 'task_ids')
+        self.result_gpu_id = _require_int(
+            _cfg_get(self.eval_config, 'result_gpu_id', 0),
+            'eval_config.result_gpu_id', 0)
+        self.expected_task_indexes = self._expected_task_indexes()
+        self._logger = logger or overwatch.info
+        self._feishu = _require_mapping(feishu or {}, 'feishu')
+        self._active: Optional[_RunState] = None
+        self._requests: dict[str, _CachedRequest] = {}
+        self._last_run_dir: Optional[Path] = None
+        self._lock = threading.RLock()
+
+    def set_logger(self, logger=None) -> None:
+        """Bind a runtime logger; ``None`` restores Overwatch."""
+        if logger is not None and not callable(logger):
+            raise TypeError('logger must be callable or None')
+        self._logger = logger or overwatch.info
+
+    @property
+    def run_dir(self) -> Optional[str]:
+        run_dir = self._active.run_dir if self._active else self._last_run_dir
+        return str(run_dir) if run_dir is not None else None
+
+    def process_event(self,
+                      event_type,
+                      request_id,
+                      run_session_id,
+                      sequence,
+                      payload,
+                      *,
+                      version=EVENT_VERSION) -> dict:
+        """Validate and persist one evaluation lifecycle event."""
+        with self._lock:
+            try:
+                return self._process_event(event_type, request_id,
+                                           run_session_id, sequence, payload,
+                                           version)
+            # Protocol and artifact errors are returned in-band.
+            except Exception as exc:
+                error = f'{type(exc).__name__}: {exc}'
+                self._log(f'[ros-eval] rejected event: {error}')
+                active = self._active
+                return {
+                    'accepted': False,
+                    'duplicate': False,
+                    'error': error,
+                    'run_dir': str(active.run_dir) if active else self.run_dir,
+                    'next_sequence': active.next_sequence if active else 1,
+                    'status': 'running' if active else 'idle',
+                }
+
+    def _process_event(self, event_type, request_id, run_session_id, sequence,
+                       payload, version) -> dict:
+        event_type = _require_string(event_type, 'event_type').lower()
+        if event_type not in EVENT_TYPES:
+            raise EvaluationEventError(f'unsupported event_type: {event_type}')
+        request_id = _require_string(request_id, 'request_id')
+        run_session_id = _require_string(run_session_id, 'run_session_id')
+        sequence = _require_int(sequence, 'sequence', 1)
+        version = _require_int(version, 'version', 1)
+        if version != EVENT_VERSION:
+            raise EvaluationEventError(f'unsupported event version {version}; '
+                                       f'expected {EVENT_VERSION}')
+        payload = _require_mapping(payload, 'payload')
+        fingerprint = json.dumps(
+            [version, event_type, run_session_id, sequence, payload],
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(',', ':'))
+
+        cached = self._requests.get(request_id)
+        if cached is not None:
+            if cached.fingerprint != fingerprint:
+                raise EvaluationEventError(
+                    f'request_id {request_id!r} was reused with different data'
+                )
+            response = copy.deepcopy(cached.response)
+            response['duplicate'] = True
+            return response
+
+        if event_type == 'run_start':
+            if self._active is not None:
+                raise EvaluationEventError(
+                    f'run {self._active.session_id!r} is already active')
+            if sequence != 1:
+                raise EvaluationEventError(
+                    f'run_start sequence must be 1, got {sequence}')
+            state = self._start_run(run_session_id, payload)
+            self._active = state
+            self._append_event(state, version, event_type, request_id,
+                               sequence, payload)
+            response = self._response(state, status='running')
+        else:
+            state = self._active
+            if state is None:
+                raise EvaluationEventError('no evaluation run is active')
+            if run_session_id != state.session_id:
+                raise EvaluationEventError(
+                    f'event session {run_session_id!r} does not match active '
+                    f'run {state.session_id!r}')
+            if sequence != state.next_sequence:
+                raise EvaluationEventError(
+                    f'expected sequence {state.next_sequence}, got {sequence}')
+            if event_type == 'episode_start':
+                self._episode_start(state, payload)
+                status = 'running'
+            elif event_type == 'episode_end':
+                self._episode_end(state, payload)
+                status = 'running'
+            else:
+                status = self._run_end(state, payload)
+                # Local finalization is intentionally completed before the
+                # run_end event is committed. All local writes are idempotent,
+                # so a transient filesystem failure can safely retry the same
+                # request and sequence without duplicating a Feishu row.
+                summary_path = self._write_summary_artifacts(state)
+            self._append_event(state, version, event_type, request_id,
+                               sequence, payload)
+            state.next_sequence += 1
+            response = self._response(state, status=status)
+            if event_type == 'run_end':
+                response.update(
+                    self._report_finalized_run(state, payload, summary_path))
+                self._last_run_dir = state.run_dir
+                self._active = None
+
+        response['error'] = ''
+        response['accepted'] = True
+        response['duplicate'] = False
+        self._requests[request_id] = _CachedRequest(
+            fingerprint=fingerprint, response=copy.deepcopy(response))
+        return response
+
+    def _start_run(self, session_id: str, payload: dict) -> _RunState:
+        schema_version = payload.get('schema_version')
+        if str(schema_version) not in {'1', '1.0'}:
+            raise EvaluationEventError(
+                f'unsupported run schema_version {schema_version!r}')
+        run_name = _require_string(
+            payload.get('run_name', ''), 'payload.run_name', allow_empty=True)
+        if run_name and (Path(run_name).name != run_name
+                         or run_name in {'.', '..'}):
+            raise EvaluationEventError(
+                'payload.run_name must be a path component')
+        seed = _require_int(payload.get('seed'), 'payload.seed')
+        episodes_per_task = _require_int(
+            payload.get('episodes_per_task'), 'payload.episodes_per_task', 1)
+        max_episode_steps = _require_int(
+            payload.get('max_episode_steps'), 'payload.max_episode_steps', 1)
+        execute_horizon = payload.get('execute_horizon')
+        if execute_horizon is not None:
+            execute_horizon = _require_int(execute_horizon,
+                                           'payload.execute_horizon', 1)
+        total_tasks = _require_int(
+            payload.get('total_tasks'), 'payload.total_tasks', 1)
+        total_episodes = _require_int(
+            payload.get('total_episodes'), 'payload.total_episodes', 1)
+        full_suite = _require_bool(
+            payload.get('full_suite'), 'payload.full_suite')
+        if total_episodes != total_tasks * episodes_per_task:
+            raise EvaluationEventError(
+                'payload.total_episodes must equal total_tasks * '
+                'episodes_per_task')
+        tasks_value = payload.get('tasks')
+        if (not isinstance(tasks_value, Sequence)
+                or isinstance(tasks_value, (str, bytes))):
+            raise EvaluationEventError('payload.tasks must be a sequence')
+        if len(tasks_value) != total_tasks:
+            raise EvaluationEventError(
+                'payload.tasks length must equal payload.total_tasks')
+        tasks_by_id = {}
+        tasks_by_index = {}
+        for position, value in enumerate(tasks_value):
+            task = _require_mapping(value, f'payload.tasks[{position}]')
+            task_id = _require_string(
+                task.get('task_id'), f'payload.tasks[{position}].task_id')
+            task_index = _require_int(
+                task.get('task_index'),
+                f'payload.tasks[{position}].task_index', 0)
+            description = _require_string(
+                task.get('description', ''),
+                f'payload.tasks[{position}].description',
+                allow_empty=True)
+            metadata = _require_mapping(
+                task.get('metadata', {}),
+                f'payload.tasks[{position}].metadata')
+            for suite_key in ('task_suite_name', 'suite'):
+                metadata_suite = metadata.get(suite_key)
+                if (metadata_suite is not None
+                        and str(metadata_suite) != self.task_suite_name):
+                    raise EvaluationEventError(
+                        f'task {task_id!r} metadata {suite_key}='
+                        f'{metadata_suite!r} does not match authoritative '
+                        'suite '
+                        f'{self.task_suite_name!r}')
+            if task_id in tasks_by_id:
+                raise EvaluationEventError(f'duplicate task_id {task_id!r}')
+            if task_index in tasks_by_index:
+                raise EvaluationEventError(
+                    f'duplicate task_index {task_index}')
+            entry = _TaskManifestEntry(task_id, task_index, description,
+                                       metadata)
+            tasks_by_id[task_id] = entry
+            tasks_by_index[task_index] = entry
+
+        run_id, run_dir = self._allocate_run_dir(run_name)
+        run_dir.mkdir(parents=True, exist_ok=False)
+        (run_dir / 'rank_progress').mkdir()
+        _write_json_atomic(run_dir / 'rank_progress' / 'rank0.json', {
+            'rank': 0,
+            'episodes': 0,
+            'successes': 0,
+        })
+        state = _RunState(
+            session_id=session_id,
+            run_id=run_id,
+            run_dir=run_dir,
+            start={
+                'schema_version': RUN_SCHEMA_VERSION,
+                'run_name': run_name,
+                'seed': seed,
+                'episodes_per_task': episodes_per_task,
+                'max_episode_steps': max_episode_steps,
+                'execute_horizon': execute_horizon,
+                'total_tasks': total_tasks,
+                'total_episodes': total_episodes,
+                'full_suite': full_suite,
+            },
+            tasks_by_id=tasks_by_id,
+            tasks_by_index=tasks_by_index,
+        )
+        self._append_log(
+            state, f'ROS evaluation session: {session_id}\n'
+            f'task_suite: {self.task_suite_name}\n'
+            f'model_family: {self.model_family}\n'
+            f'config: {self.config_path}\n'
+            f'ckpt: {self.ckpt_path}\n')
+        self._log(f'[ros-eval] run_start session={session_id} '
+                  f'episodes={total_episodes} run_dir={run_dir}')
+        return state
+
+    def _episode_start(self, state: _RunState, payload: dict) -> None:
+        if state.current_episode is not None:
+            raise EvaluationEventError('an episode is already active')
+        task, episode_index, seed, description = self._episode_identity(
+            state, payload)
+        started_at, started_epoch = _require_datetime(
+            payload.get('started_at'), 'payload.started_at')
+        key = (task.task_index, episode_index)
+        if key in state.completed_keys:
+            raise EvaluationEventError(f'episode {key} already completed')
+        state.current_episode = {
+            'task_id': task.task_id,
+            'task_index': task.task_index,
+            'description': description,
+            'episode_index': episode_index,
+            'seed': seed,
+            'started_at': started_at,
+            'started_epoch': started_epoch,
+        }
+        self._append_log(
+            state,
+            f'Evaluating Task {task.task_index}, Trial {episode_index}\n'
+            f'\nTask: {description}\n'
+            f'Starting episode {episode_index + 1}...\n')
+        self._log(f'Evaluating Task {task.task_index}, Trial {episode_index}')
+        self._log(f'\nTask: {description}')
+        self._log(f'Starting episode {episode_index + 1}...')
+
+    def _episode_end(self, state: _RunState, payload: dict) -> None:
+        current = state.current_episode
+        if current is None:
+            raise EvaluationEventError(
+                'episode_end has no matching episode_start')
+        task, episode_index, seed, description = self._episode_identity(
+            state, payload)
+        for key, value in (
+            ('task_index', task.task_index),
+            ('episode_index', episode_index),
+            ('seed', seed),
+            ('description', description),
+        ):
+            if current[key] != value:
+                raise EvaluationEventError(
+                    f'episode_end {key} does not match episode_start')
+        success = _require_bool(payload.get('success'), 'payload.success')
+        episode_return = _require_number(
+            payload.get('episode_return'), 'payload.episode_return')
+        steps = _require_int(payload.get('steps'), 'payload.steps', 0)
+        duration = _require_number(
+            payload.get('duration_s'), 'payload.duration_s', 0.0)
+        termination_reason = _require_string(
+            payload.get('termination_reason'), 'payload.termination_reason')
+        model_calls = _require_int(
+            payload.get('model_calls'), 'payload.model_calls', 0)
+        info = _require_mapping(payload.get('info', {}), 'payload.info')
+        prediction_metadata = payload.get('prediction_metadata', [])
+        if (not isinstance(prediction_metadata, Sequence)
+                or isinstance(prediction_metadata, (str, bytes))):
+            raise EvaluationEventError(
+                'payload.prediction_metadata must be a sequence')
+        prediction_metadata = json.loads(
+            json.dumps(list(prediction_metadata), ensure_ascii=False))
+        completed = _require_int(
+            payload.get('completed_episodes'), 'payload.completed_episodes', 1)
+        total = _require_int(
+            payload.get('total_episodes'), 'payload.total_episodes', 1)
+        if total != state.start['total_episodes']:
+            raise EvaluationEventError(
+                'episode_end total_episodes changed during the run')
+        if completed != len(state.episodes) + 1:
+            raise EvaluationEventError(
+                f'episode_end completed_episodes must be '
+                f'{len(state.episodes) + 1}')
+        result = {
+            **current,
+            'success': success,
+            'episode_return': episode_return,
+            'steps': steps,
+            'duration_s': duration,
+            'termination_reason': termination_reason,
+            'model_calls': model_calls,
+            'info': info,
+            'prediction_metadata': prediction_metadata,
+        }
+        state.episodes.append(result)
+        state.completed_keys.add((task.task_index, episode_index))
+        state.current_episode = None
+        successes = sum(bool(item['success']) for item in state.episodes)
+        success_rate = successes / len(state.episodes) * 100
+        _write_json_atomic(state.run_dir / 'rank_progress' / 'rank0.json', {
+            'rank': 0,
+            'episodes': len(state.episodes),
+            'successes': successes,
+        })
+        self._append_log(
+            state, f'Success: {success}\n'
+            f'# local episodes completed so far: {len(state.episodes)}\n'
+            f'# local successes: {successes} ({success_rate:.1f}%)\n')
+        self._log('[eval-progress] '
+                  f'episodes={len(state.episodes)}/'
+                  f"{state.start['total_episodes']} "
+                  f'successes={successes} '
+                  f'success_rate={success_rate:.2f}%')
+
+    def _episode_identity(
+            self, state: _RunState,
+            payload: dict) -> tuple[_TaskManifestEntry, int, int, str]:
+        task_id = _require_string(payload.get('task_id'), 'payload.task_id')
+        task_index = _require_int(
+            payload.get('task_index'), 'payload.task_index', 0)
+        task = state.tasks_by_id.get(task_id)
+        if task is None or task.task_index != task_index:
+            raise EvaluationEventError(
+                f'task {task_id!r}/{task_index} is not in the run manifest')
+        description = _require_string(
+            payload.get('description', ''),
+            'payload.description',
+            allow_empty=True)
+        if description != task.description:
+            raise EvaluationEventError(
+                f'task {task_id!r} description changed during the run')
+        episode_index = _require_int(
+            payload.get('episode_index'), 'payload.episode_index', 0)
+        if episode_index >= state.start['episodes_per_task']:
+            raise EvaluationEventError(
+                'payload.episode_index exceeds episodes_per_task')
+        seed = _require_int(payload.get('seed'), 'payload.seed')
+        return task, episode_index, seed, description
+
+    def _run_end(self, state: _RunState, payload: dict) -> str:
+        status = _require_string(payload.get('status'),
+                                 'payload.status').lower()
+        if status not in {'finished', 'failed', 'interrupted'}:
+            raise EvaluationEventError(
+                'payload.status must be finished, failed, or interrupted')
+        if status == 'finished' and state.current_episode is not None:
+            raise EvaluationEventError(
+                'finished run still has an active episode')
+        full_suite = _require_bool(
+            payload.get('full_suite'), 'payload.full_suite')
+        completed = _require_int(
+            payload.get('completed_episodes'), 'payload.completed_episodes', 0)
+        total = _require_int(
+            payload.get('total_episodes'), 'payload.total_episodes', 1)
+        _require_datetime(payload.get('finished_at'), 'payload.finished_at')
+        _require_number(payload.get('duration_s'), 'payload.duration_s', 0.0)
+        if completed != len(state.episodes):
+            raise EvaluationEventError(
+                'run_end completed_episodes does not match accepted episodes')
+        if total != state.start['total_episodes']:
+            raise EvaluationEventError('run_end total_episodes changed')
+        if full_suite != state.start['full_suite']:
+            raise EvaluationEventError('run_end full_suite changed during run')
+        if 'error' in payload:
+            json.dumps(payload['error'], ensure_ascii=False)
+        state.current_episode = None
+        self._append_log(
+            state, f'Run status: {status}\n'
+            f'# episodes completed: {completed}\n'
+            f'# successes: '
+            f"{sum(bool(item['success']) for item in state.episodes)}\n")
+        self._log(f'[ros-eval] run_end status={status} '
+                  f'episodes={completed}/{total} run_dir={state.run_dir}')
+        return status
+
+    def _report_finalized_run(self, state: _RunState, end: dict,
+                              summary_path: Path) -> dict:
+        eligible, reason = self._feishu_eligibility(state, end)
+        if not eligible:
+            self._log(f'[ros-eval] Feishu skipped: {reason}')
+            return {
+                'reported_to_feishu': False,
+                'report_reason': reason,
+                'summary_path': str(summary_path),
+            }
+        try:
+            result = maybe_report_summary_to_feishu(
+                str(summary_path),
+                'libero',
+                sheet_url=self._feishu.get('sheet_url'),
+                app_id=self._feishu.get('app_id'),
+                app_secret=self._feishu.get('app_secret'),
+                config=self.config_path,
+                timeout=float(self._feishu.get('timeout', 10.0)),
+                logger=self._log,
+                log_unconfigured=True)
+        except Exception as exc:  # Feishu is best effort after local commit.
+            reason = f'{type(exc).__name__}: {exc}'
+            self._log(f'[ros-eval] Feishu skipped: {reason}')
+            return {
+                'reported_to_feishu': False,
+                'report_reason': reason,
+                'summary_path': str(summary_path),
+            }
+        return {
+            'reported_to_feishu': bool(result.wrote),
+            'report_reason': result.reason,
+            'summary_path': str(summary_path),
+        }
+
+    def _write_summary_artifacts(self, state: _RunState) -> Path:
+        grouped = defaultdict(list)
+        for episode in state.episodes:
+            grouped[episode['task_index']].append(episode)
+        suite_dir = state.run_dir / self.task_suite_name
+        status_dir = state.run_dir / 'task_status'
+        suite_dir.mkdir(exist_ok=True)
+        status_dir.mkdir(exist_ok=True)
+        task_results = {}
+        total_successes = 0
+        total_trials = 0
+        total_time = 0.0
+        max_time = 0.0
+        for task_index in sorted(grouped):
+            episodes = sorted(
+                grouped[task_index], key=lambda item: item['episode_index'])
+            task = state.tasks_by_index[task_index]
+            successes = sum(bool(item['success']) for item in episodes)
+            duration = sum(float(item['duration_s']) for item in episodes)
+            success_episodes = [
+                item['episode_index'] for item in episodes if item['success']
+            ]
+            failure_episodes = [
+                item['episode_index'] for item in episodes
+                if not item['success']
+            ]
+            start_epoch = min(item['started_epoch'] for item in episodes)
+            start_time = time.strftime('%Y-%m-%d %H:%M:%S',
+                                       time.localtime(start_epoch))
+            count = len(episodes)
+            per_task = {
+                'task_suite': self.task_suite_name,
+                'task_id': task_index,
+                'task_description': task.description,
+                'successes': successes,
+                'total_episodes': count,
+                'success_episodes': success_episodes,
+                'failure_episodes': failure_episodes,
+                'start_time': start_time,
+                'duration': duration,
+                'gpu_id': self.result_gpu_id,
+            }
+            _write_json_atomic(suite_dir / f'task{task_index}_results.json',
+                               per_task)
+            manager_suite_dir = self.result_root / self.task_suite_name
+            manager_suite_dir.mkdir(parents=True, exist_ok=True)
+            _write_json_atomic(
+                manager_suite_dir /
+                f'gpu{self.result_gpu_id}_task{task_index}_results.json',
+                per_task)
+            complete = count == state.start['episodes_per_task']
+            task_state = 'SUCCESS' if complete else 'PARTIAL'
+            (status_dir /
+             f'{self.task_suite_name}_task{task_index}.status').write_text(
+                 f'{task_state}|{successes}|{count}|{int(start_epoch)}',
+                 encoding='utf-8')
+            rate = successes / count * 100
+            task_results[f'{self.task_suite_name}_{task_index}'] = {
+                'success_rate': rate,
+                'duration': duration,
+                'total_episodes': count,
+                'successes': successes,
+                'task_description': task.description,
+            }
+            total_successes += successes
+            total_trials += count
+            total_time += duration
+            max_time = max(max_time, duration)
+            self._log(f'Task {task_index} completed: '
+                      f'{successes}/{count} successes')
+            self._log(f'Time taken: {duration:.2f} seconds')
+
+        completed_tasks = len(task_results)
+        success_rate = total_successes / max(total_trials, 1) * 100
+        average_time = total_time / max(completed_tasks, 1)
+        (state.run_dir / 'failed_tasks.txt').write_text('', encoding='utf-8')
+        self._write_summary_text(state, completed_tasks, total_trials,
+                                 total_successes, success_rate, total_time,
+                                 average_time, max_time)
+        self._write_summary_csv(state, success_rate, average_time, max_time)
+        self._write_task_csv(state, task_results)
+        summary = {
+            'run_id': state.run_id,
+            'ckpt': self.ckpt_path,
+            'config': Path(self.config_path).stem,
+            'suite_stats': {
+                self.task_suite_name: {
+                    'total_tasks': completed_tasks,
+                    'total_trials': total_trials,
+                    'total_successes': total_successes,
+                    'total_time': total_time,
+                    'max_time': max_time,
+                }
+            },
+            'task_results': task_results,
+            'overall': {
+                'average_success_rate': success_rate,
+                'total_time': total_time,
+                'average_task_time': average_time,
+            },
+        }
+        summary_path = state.run_dir / 'summary.json'
+        _write_json_atomic(summary_path, summary)
+        self._log(f'# episodes completed: {total_trials}')
+        self._log(f'# successes: {total_successes} ({success_rate:.1f}%)')
+        self._log(f'[ros-eval] wrote LIBERO summary artifacts to '
+                  f'{state.run_dir}')
+        return summary_path
+
+    def _allocate_run_dir(self, run_name: str) -> tuple[str, Path]:
+        """Allocate a timestamp run id without overwriting prior runs."""
+        checkpoint_root = (
+            self.result_root / 'eval_runs' / Path(self.ckpt_path).stem)
+        now = time.time()
+        for second_offset in range(86400):
+            timestamp = time.strftime('%Y_%m_%d-%H_%M_%S',
+                                      time.localtime(now + second_offset))
+            run_id = (f'EVAL-{self.task_suite_name}-{self.model_family}-'
+                      f'{timestamp}')
+            if run_name:
+                run_id = f'{run_id}-{run_name}'
+            run_dir = checkpoint_root / run_id
+            if not run_dir.exists():
+                return run_id, run_dir
+        raise FileExistsError(
+            f'Could not allocate a unique evaluation run under '
+            f'{checkpoint_root}')
+
+    def _write_summary_text(self, state, completed_tasks, total_trials,
+                            total_successes, success_rate, total_time,
+                            average_time, max_time) -> None:
+        cfg = self.eval_config
+        task_ids = sorted(state.tasks_by_index)
+        lines = [
+            f'task_suite: {self.task_suite_name}',
+            f'model_family: {self.model_family}',
+            f'task_ids: {task_ids}',
+            f"num_trials_per_task: {state.start['episodes_per_task']}",
+            f"eval_chunk_size: {state.start['execute_horizon']}",
+            f"num_steps_wait: {_cfg_get(cfg, 'num_steps_wait', None)}",
+            f'num_inference_steps: '
+            f"{_cfg_get(cfg, 'num_inference_steps', None)}",
+            f"max_steps: {state.start['max_episode_steps']}",
+            'eval_shard_strategy: ros',
+            f'preprocess_every_step: '
+            f"{_cfg_get(cfg, 'preprocess_every_step', None)}",
+            f'save_rollout_videos: '
+            f"{_cfg_get(cfg, 'save_rollout_videos', False)}",
+            f'save_failed_rollout_videos: '
+            f"{_cfg_get(cfg, 'save_failed_rollout_videos', False)}",
+            f'save_multi_view_rollout_videos: '
+            f"{_cfg_get(cfg, 'save_multi_view_rollout_videos', False)}",
+            f"rollout_dir: {_cfg_get(cfg, 'rollout_dir', None)}",
+            f"seed: {state.start['seed']}",
+            f'# successes: {total_successes} / {total_trials} '
+            f'({success_rate:.1f}%)',
+            '',
+            '=== Evaluation Results Summary ===',
+            '',
+            f'{self.task_suite_name}:',
+            f'- Tasks completed: {completed_tasks}',
+            f'- Total attempts: {total_trials}',
+            f'- Successful attempts: {total_successes}',
+            f'- Success rate: {success_rate:.2f}%',
+            f'- Total time: {_format_duration(total_time)}',
+            f'- Average time per task: {_format_duration(average_time)}',
+            f'- Longest task time: {_format_duration(max_time)}',
+        ]
+        (state.run_dir / 'summary.txt').write_text(
+            '\n'.join(lines) + '\n', encoding='utf-8')
+
+    def _write_summary_csv(self, state, success_rate, average_time,
+                           max_time) -> None:
+        with (state.run_dir / 'summary.csv').open(
+                'w', newline='', encoding='utf-8') as stream:
+            stream.write(f'{Path(self.ckpt_path).name}\n')
+            writer = csv.writer(stream)
+            writer.writerow(['', self.task_suite_name, 'Overall'])
+            writer.writerow([
+                'Success Rate (%)', f'{success_rate:.2f}',
+                f'{success_rate:.2f}'
+            ])
+            writer.writerow([
+                'Average Time (s)', f'{average_time:.2f}',
+                f'{average_time:.2f}'
+            ])
+            writer.writerow(
+                ['Max Time (s)', f'{max_time:.2f}', f'{max_time:.2f}'])
+
+    def _write_task_csv(self, state, task_results) -> None:
+        with (state.run_dir / 'task_success_rates.csv').open(
+                'w', newline='', encoding='utf-8') as stream:
+            writer = csv.writer(stream)
+            writer.writerow(['Task', 'Description', 'Success Rate (%)'])
+            for task_index in sorted(state.tasks_by_index):
+                key = f'{self.task_suite_name}_{task_index}'
+                if key not in task_results:
+                    continue
+                result = task_results[key]
+                writer.writerow([
+                    key, result['task_description'],
+                    f"{result['success_rate']:.2f}"
+                ])
+
+    def _feishu_eligibility(self, state: _RunState,
+                            end: dict) -> tuple[bool, str]:
+        if end['status'].lower() != 'finished':
+            return False, 'run status is not finished'
+        if not state.start['full_suite'] or not end['full_suite']:
+            return False, 'run is not marked as a full suite'
+        if self.configured_task_ids is not None:
+            return False, 'authoritative eval config contains a task filter'
+        if self.expected_task_indexes is None:
+            return False, 'complete authoritative task manifest is unknown'
+        selected = set(state.tasks_by_index)
+        if selected != self.expected_task_indexes:
+            return (False,
+                    'selected task indexes do not match the full manifest')
+        if state.start['total_tasks'] != len(self.expected_task_indexes):
+            return False, 'total task count does not match eval metadata'
+        if state.start['episodes_per_task'] != self.num_trials_per_task:
+            return False, 'episodes_per_task does not match eval metadata'
+        expected_total = len(self.expected_task_indexes) * \
+            self.num_trials_per_task
+        if (end['completed_episodes'] != end['total_episodes']
+                or end['total_episodes'] != expected_total):
+            return False, 'completed episode total is not the full suite total'
+        counts = defaultdict(int)
+        for episode in state.episodes:
+            counts[episode['task_index']] += 1
+        if any(counts[index] != self.num_trials_per_task
+               for index in self.expected_task_indexes):
+            return False, 'one or more tasks has an incomplete episode count'
+        return True, 'eligible full-suite evaluation'
+
+    def _expected_task_indexes(self) -> Optional[set[int]]:
+        manifest = _cfg_get(self.eval_config, 'task_manifest')
+        if manifest is not None:
+            indexes = set()
+            for position, task in enumerate(manifest):
+                task = _require_mapping(
+                    task, f'eval_config.task_manifest[{position}]')
+                indexes.add(
+                    _require_int(
+                        task.get('task_index'),
+                        f'eval_config.task_manifest[{position}].task_index',
+                        0))
+            return indexes
+        total_tasks = _cfg_get(self.eval_config, 'total_tasks')
+        if total_tasks is None:
+            total_tasks = _cfg_get(self.eval_config, 'num_tasks')
+        if total_tasks is None:
+            total_tasks = LIBERO_SUITE_TASK_COUNTS.get(self.task_suite_name)
+        if total_tasks is None:
+            return None
+        total_tasks = _require_int(total_tasks, 'eval_config.total_tasks', 1)
+        return set(range(total_tasks))
+
+    def _append_event(self, state, version, event_type, request_id, sequence,
+                      payload) -> None:
+        record = {
+            'event_version': version,
+            'event_type': event_type,
+            'request_id': request_id,
+            'run_session_id': state.session_id,
+            'sequence': sequence,
+            'recorded_at': datetime.now().astimezone().isoformat(),
+            'payload': payload,
+        }
+        with (state.run_dir / 'events.jsonl').open(
+                'a', encoding='utf-8') as stream:
+            stream.write(json.dumps(record, ensure_ascii=False) + '\n')
+            stream.flush()
+            os.fsync(stream.fileno())
+
+    @staticmethod
+    def _append_log(state: _RunState, message: str) -> None:
+        with (state.run_dir / 'rank0.txt').open(
+                'a', encoding='utf-8') as stream:
+            stream.write(message)
+            stream.flush()
+
+    def _response(self, state: _RunState, status: str) -> dict:
+        return {
+            'accepted': True,
+            'duplicate': False,
+            'error': '',
+            'run_dir': str(state.run_dir),
+            'next_sequence': state.next_sequence,
+            'status': status,
+        }
+
+    def _log(self, message: str) -> None:
+        try:
+            self._logger(message)
+        # Logging must never fail evaluation reporting.
+        except Exception as exc:
+            overwatch.warning(f'[ros-eval] logger failed: {exc}; {message}')
+
+
+__all__ = ['EvaluationEventError', 'FluxVLAROSEvaluationReporter']

--- a/fluxvla/engines/runners/serving/evaluation_reporter.py
+++ b/fluxvla/engines/runners/serving/evaluation_reporter.py
@@ -1,3 +1,16 @@
+# Copyright 2026 Limx Dynamics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Durable ROS evaluation events and native FluxVLA evaluation artifacts.
 
 ``FluxVLAROSEvaluationReporter`` is the small adapter boundary used by ROS 1
@@ -11,6 +24,7 @@ The class deliberately has no ROS dependency.  Server adapters may construct
 it before ROS initialization and later replace the default Overwatch logger
 with :meth:`set_logger`.
 """
+
 from __future__ import annotations
 import copy
 import csv

--- a/fluxvla/engines/runners/serving/evaluation_reporter.py
+++ b/fluxvla/engines/runners/serving/evaluation_reporter.py
@@ -1,11 +1,11 @@
-"""Durable ROS evaluation events and native FluxVLA LIBERO artifacts.
+"""Durable ROS evaluation events and native FluxVLA evaluation artifacts.
 
 ``FluxVLAROSEvaluationReporter`` is the small adapter boundary used by ROS 1
 and ROS 2 servers.  A server passes versioned ``run_start``,
 ``episode_start``, ``episode_end`` and ``run_end`` events to
 ``process_event``.  The reporter validates ordering and idempotency, journals
-accepted events, maintains native live progress, and writes the same result
-schema as :class:`LiberoEvalRunner`.
+accepted events, maintains native live progress, and writes the native LIBERO
+or RoboCasa result schema selected by the evaluation config.
 
 The class deliberately has no ROS dependency.  Server adapters may construct
 it before ROS initialization and later replace the default Overwatch logger
@@ -43,6 +43,8 @@ LIBERO_SUITE_TASK_COUNTS = {
     'libero_10': 10,
     'libero_90': 90,
 }
+REPORT_KINDS = frozenset({'libero', 'robocasa'})
+ROBOCASA_GROUP_ORDER = ('Cabinet', 'Drawer', 'Microwave', 'Generalization')
 
 
 class EvaluationEventError(ValueError):
@@ -97,6 +99,23 @@ def _runner_eval_config(config):
              for key, value in config.items() if key != 'runner'})
         return merged
     return runner
+
+
+def _resolve_report_kind(config, explicit=None) -> str:
+    value = explicit
+    if value is None:
+        value = _cfg_get(config, 'report_kind')
+    if value is None:
+        value = _cfg_get(config, 'benchmark')
+    if value is None:
+        runner_type = str(_cfg_get(config, 'type', '')).lower()
+        value = 'robocasa' if 'robocasa' in runner_type else 'libero'
+    value = _require_string(value, 'report_kind').lower()
+    if value not in REPORT_KINDS:
+        raise EvaluationEventError(
+            f'report_kind must be one of {sorted(REPORT_KINDS)}, got '
+            f'{value!r}')
+    return value
 
 
 def _require_mapping(value, name: str) -> dict:
@@ -166,6 +185,16 @@ def _format_duration(seconds: float) -> str:
     return f'{hours:02d}h{remainder // 60:02d}m{remainder % 60:02d}s'
 
 
+def _robocasa_group_name(env_name: str) -> str:
+    if 'ToCabinet' in env_name:
+        return 'Cabinet'
+    if 'ToDrawer' in env_name:
+        return 'Drawer'
+    if 'ToMicrowave' in env_name:
+        return 'Microwave'
+    return 'Generalization'
+
+
 def _write_json_atomic(path: Path, value: Any) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     temporary = path.with_name(f'{path.name}.tmp')
@@ -184,9 +213,10 @@ class FluxVLAROSEvaluationReporter:
             individual runs are placed below ``eval_runs/<checkpoint stem>``.
         config_path: Authoritative FluxVLA MMEngine config path.
         ckpt_path: Authoritative model checkpoint path.
-        eval_config: The selected FluxVLA eval runner config. At minimum it
-            must define ``task_suite_name``, ``model_family`` and
-            ``num_trials_per_task``.
+        eval_config: The selected FluxVLA eval runner config. It must define
+            ``model_family`` and ``num_trials_per_task``. LIBERO additionally
+            requires ``task_suite_name``; RoboCasa requires ``task_list``.
+        report_kind: Optional explicit ``libero`` or ``robocasa`` selector.
         logger: Optional ``Callable[[str], None]``. Defaults to Overwatch.
         feishu: Optional mapping with ``sheet_url``, ``app_id``, ``app_secret``
             and ``timeout``. Missing credentials retain the native environment
@@ -204,13 +234,16 @@ class FluxVLAROSEvaluationReporter:
                  ckpt_path,
                  eval_config,
                  logger=None,
-                 feishu=None):
+                 feishu=None,
+                 report_kind=None):
         self.result_root = Path(result_root).expanduser().resolve()
         self.config_path = str(Path(config_path).expanduser().resolve())
         self.ckpt_path = str(Path(ckpt_path).expanduser().resolve())
         self.eval_config = _runner_eval_config(eval_config)
+        self.report_kind = _resolve_report_kind(self.eval_config, report_kind)
+        suite_default = 'robocasa' if self.report_kind == 'robocasa' else None
         self.task_suite_name = _require_string(
-            _cfg_get(self.eval_config, 'task_suite_name'),
+            _cfg_get(self.eval_config, 'task_suite_name', suite_default),
             'eval_config.task_suite_name')
         self.model_family = _require_string(
             _cfg_get(self.eval_config, 'model_family'),
@@ -218,6 +251,11 @@ class FluxVLAROSEvaluationReporter:
         self.num_trials_per_task = _require_int(
             _cfg_get(self.eval_config, 'num_trials_per_task'),
             'eval_config.num_trials_per_task', 1)
+        self.action_order = _require_string(
+            _cfg_get(self.eval_config, 'action_order',
+                     'n15' if self.model_family == 'groot' else 'fluxvla'),
+            'eval_config.action_order')
+        self.task_list = self._configured_task_list()
         self.configured_task_ids = _cfg_get(self.eval_config, 'task_ids')
         self.result_gpu_id = _require_int(
             _cfg_get(self.eval_config, 'result_gpu_id', 0),
@@ -430,6 +468,13 @@ class FluxVLAROSEvaluationReporter:
             metadata = _require_mapping(
                 task.get('metadata', {}),
                 f'payload.tasks[{position}].metadata')
+            metadata_benchmark = metadata.get('benchmark')
+            if (metadata_benchmark is not None
+                    and str(metadata_benchmark).lower() != self.report_kind):
+                raise EvaluationEventError(
+                    f'task {task_id!r} metadata benchmark='
+                    f'{metadata_benchmark!r} does not match authoritative '
+                    f'report kind {self.report_kind!r}')
             for suite_key in ('task_suite_name', 'suite'):
                 metadata_suite = metadata.get(suite_key)
                 if (metadata_suite is not None
@@ -439,6 +484,12 @@ class FluxVLAROSEvaluationReporter:
                         f'{metadata_suite!r} does not match authoritative '
                         'suite '
                         f'{self.task_suite_name!r}')
+            if self.report_kind == 'robocasa':
+                self._validate_robocasa_manifest_entry(
+                    task_id=task_id,
+                    task_index=task_index,
+                    metadata=metadata,
+                )
             if task_id in tasks_by_id:
                 raise EvaluationEventError(f'duplicate task_id {task_id!r}')
             if task_index in tasks_by_index:
@@ -687,7 +738,7 @@ class FluxVLAROSEvaluationReporter:
         try:
             result = maybe_report_summary_to_feishu(
                 str(summary_path),
-                'libero',
+                self.report_kind,
                 sheet_url=self._feishu.get('sheet_url'),
                 app_id=self._feishu.get('app_id'),
                 app_secret=self._feishu.get('app_secret'),
@@ -710,6 +761,11 @@ class FluxVLAROSEvaluationReporter:
         }
 
     def _write_summary_artifacts(self, state: _RunState) -> Path:
+        if self.report_kind == 'robocasa':
+            return self._write_robocasa_summary_artifacts(state)
+        return self._write_libero_summary_artifacts(state)
+
+    def _write_libero_summary_artifacts(self, state: _RunState) -> Path:
         grouped = defaultdict(list)
         for episode in state.episodes:
             grouped[episode['task_index']].append(episode)
@@ -815,6 +871,187 @@ class FluxVLAROSEvaluationReporter:
         self._log(f'# episodes completed: {total_trials}')
         self._log(f'# successes: {total_successes} ({success_rate:.1f}%)')
         self._log(f'[ros-eval] wrote LIBERO summary artifacts to '
+                  f'{state.run_dir}')
+        return summary_path
+
+    def _write_robocasa_summary_artifacts(self, state: _RunState) -> Path:
+        grouped = defaultdict(list)
+        for episode in state.episodes:
+            grouped[episode['task_index']].append(episode)
+
+        task_result_dir = state.run_dir / 'robocasa'
+        status_dir = state.run_dir / 'task_status'
+        manager_result_dir = self.result_root / 'robocasa'
+        task_result_dir.mkdir(exist_ok=True)
+        status_dir.mkdir(exist_ok=True)
+        manager_result_dir.mkdir(parents=True, exist_ok=True)
+        group_stats = {
+            group: {
+                'total_tasks': 0,
+                'total_trials': 0,
+                'total_successes': 0,
+                'total_time': 0.0,
+                'max_time': 0.0,
+            }
+            for group in ROBOCASA_GROUP_ORDER
+        }
+        task_stats = {}
+        total_trials = 0
+        total_successes = 0
+        total_time = 0.0
+        overall_max_time = 0.0
+        incomplete_tasks = []
+
+        for task_index in sorted(state.tasks_by_index):
+            episodes = sorted(
+                grouped.get(task_index, ()),
+                key=lambda item: item['episode_index'])
+            count = len(episodes)
+            if count == 0:
+                incomplete_tasks.append(task_index)
+                continue
+            env_name = self.task_list[task_index]
+            group = _robocasa_group_name(env_name)
+            successes = sum(bool(item['success']) for item in episodes)
+            duration = sum(float(item['duration_s']) for item in episodes)
+            rate = successes / count * 100
+            stats = group_stats[group]
+            stats['total_tasks'] += 1
+            stats['total_trials'] += count
+            stats['total_successes'] += successes
+            stats['total_time'] += duration
+            stats['max_time'] = max(stats['max_time'], duration)
+            task_stats[env_name] = {
+                'task_id': task_index,
+                'group': group,
+                'total_episodes': count,
+                'successes': successes,
+                'success_rate': rate,
+                'duration': duration,
+            }
+            per_task = {
+                'task_id': task_index,
+                'env_name': env_name,
+                'group': group,
+                'successes': successes,
+                'total_episodes': count,
+                'success_rate': rate,
+                'duration': duration,
+                'gpu_id': self.result_gpu_id,
+            }
+            _write_json_atomic(
+                task_result_dir / f'task{task_index}_results.json', per_task)
+            _write_json_atomic(
+                manager_result_dir /
+                f'gpu{self.result_gpu_id}_task{task_index}_results.json',
+                per_task)
+            complete = count == state.start['episodes_per_task']
+            if not complete:
+                incomplete_tasks.append(task_index)
+            start_epoch = min(item['started_epoch'] for item in episodes)
+            task_state = 'SUCCESS' if complete else 'PARTIAL'
+            (status_dir / f'robocasa_task{task_index}.status').write_text(
+                f'{task_state}|{successes}|{count}|{int(start_epoch)}',
+                encoding='utf-8')
+            total_trials += count
+            total_successes += successes
+            total_time += duration
+            overall_max_time = max(overall_max_time, duration)
+            self._log(f'Task {task_index} ({env_name}) completed: '
+                      f'{successes}/{count} successes')
+            self._log(f'Time taken: {duration:.2f} seconds')
+
+        overall_rate = total_successes / max(total_trials, 1) * 100
+        with (state.run_dir / 'summary.csv').open(
+                'w', newline='', encoding='utf-8') as stream:
+            writer = csv.writer(stream)
+            writer.writerow(['', *ROBOCASA_GROUP_ORDER, 'all'])
+            group_rates = []
+            for group in ROBOCASA_GROUP_ORDER:
+                stats = group_stats[group]
+                if stats['total_trials']:
+                    rate = (
+                        stats['total_successes'] / stats['total_trials'] * 100)
+                    group_rates.append(f'{rate:.2f}')
+                else:
+                    group_rates.append('')
+            writer.writerow(
+                ['Success Rate (%)', *group_rates, f'{overall_rate:.2f}'])
+            writer.writerow([
+                'Episodes', *[
+                    group_stats[group]['total_trials']
+                    for group in ROBOCASA_GROUP_ORDER
+                ], total_trials
+            ])
+            writer.writerow([
+                'Successes', *[
+                    group_stats[group]['total_successes']
+                    for group in ROBOCASA_GROUP_ORDER
+                ], total_successes
+            ])
+
+        with (state.run_dir / 'task_success_rates.csv').open(
+                'w', newline='', encoding='utf-8') as stream:
+            writer = csv.writer(stream)
+            writer.writerow(
+                ['Task', 'Group', 'Successes', 'Episodes', 'Success Rate (%)'])
+            for env_name, stats in task_stats.items():
+                writer.writerow([
+                    env_name, stats['group'], stats['successes'],
+                    stats['total_episodes'], f"{stats['success_rate']:.2f}"
+                ])
+
+        text_lines = ['=== RoboCasa Evaluation Results Summary ===']
+        for group in ROBOCASA_GROUP_ORDER:
+            stats = group_stats[group]
+            rate = (
+                stats['total_successes'] / max(stats['total_trials'], 1) *
+                100 if stats['total_trials'] else 0.0)
+            text_lines.extend([
+                '',
+                f'{group}:',
+                f"- Tasks completed: {stats['total_tasks']}",
+                f"- Total attempts: {stats['total_trials']}",
+                f"- Successful attempts: {stats['total_successes']}",
+                f'- Success rate: {rate:.2f}%',
+                f"- Total time: {_format_duration(stats['total_time'])}",
+            ])
+        text_lines.extend([
+            '',
+            'Overall statistics:',
+            f'- Success rate: {overall_rate:.2f}%',
+            f'- Total attempts: {total_trials}',
+            f'- Successful attempts: {total_successes}',
+            f'- Total time: {_format_duration(total_time)}',
+        ])
+        (state.run_dir / 'summary.txt').write_text(
+            '\n'.join(text_lines) + '\n', encoding='utf-8')
+        (state.run_dir / 'failed_tasks.txt').write_text(
+            ''.join(f'{task_index}\n' for task_index in incomplete_tasks),
+            encoding='utf-8')
+
+        summary = {
+            'run_id': state.run_id,
+            'ckpt': self.ckpt_path,
+            'config': self.config_path,
+            'model_family': self.model_family,
+            'action_order': self.action_order,
+            'task_ids': sorted(state.tasks_by_index),
+            'group_stats': group_stats,
+            'task_stats': task_stats,
+            'overall': {
+                'success_rate': overall_rate,
+                'total_episodes': total_trials,
+                'successes': total_successes,
+                'total_time': total_time,
+                'max_time': overall_max_time,
+            },
+        }
+        summary_path = state.run_dir / 'summary.json'
+        _write_json_atomic(summary_path, summary)
+        self._log(f'# episodes completed: {total_trials}')
+        self._log(f'# successes: {total_successes} ({overall_rate:.1f}%)')
+        self._log(f'[ros-eval] wrote RoboCasa summary artifacts to '
                   f'{state.run_dir}')
         return summary_path
 
@@ -945,6 +1182,8 @@ class FluxVLAROSEvaluationReporter:
         return True, 'eligible full-suite evaluation'
 
     def _expected_task_indexes(self) -> Optional[set[int]]:
+        if self.task_list is not None:
+            return set(range(len(self.task_list)))
         manifest = _cfg_get(self.eval_config, 'task_manifest')
         if manifest is not None:
             indexes = set()
@@ -966,6 +1205,48 @@ class FluxVLAROSEvaluationReporter:
             return None
         total_tasks = _require_int(total_tasks, 'eval_config.total_tasks', 1)
         return set(range(total_tasks))
+
+    def _configured_task_list(self) -> Optional[tuple[str, ...]]:
+        if self.report_kind != 'robocasa':
+            return None
+        value = _cfg_get(self.eval_config, 'task_list')
+        if (not isinstance(value, Sequence) or isinstance(value,
+                                                          (str, bytes))):
+            raise EvaluationEventError(
+                'eval_config.task_list must be a sequence for RoboCasa')
+        task_list = tuple(
+            _require_string(item, f'eval_config.task_list[{index}]')
+            for index, item in enumerate(value))
+        if not task_list:
+            raise EvaluationEventError(
+                'eval_config.task_list cannot be empty for RoboCasa')
+        if len(task_list) != len(set(task_list)):
+            raise EvaluationEventError(
+                'eval_config.task_list cannot contain duplicate env names')
+        return task_list
+
+    def _validate_robocasa_manifest_entry(self, task_id: str, task_index: int,
+                                          metadata: dict) -> None:
+        if self.task_list is None or task_index >= len(self.task_list):
+            raise EvaluationEventError(
+                f'RoboCasa task index {task_index} is outside the configured '
+                'task_list')
+        if task_id != str(task_index):
+            raise EvaluationEventError(
+                f'RoboCasa task id {task_id!r} must equal its configured '
+                f'index {task_index!r}')
+        expected_env = self.task_list[task_index]
+        actual_env = metadata.get('env_name', metadata.get('task_name'))
+        if actual_env != expected_env:
+            raise EvaluationEventError(
+                f'RoboCasa task {task_index} env_name {actual_env!r} does '
+                f'not match configured task_list entry {expected_env!r}')
+        expected_group = _robocasa_group_name(expected_env)
+        actual_group = metadata.get('group')
+        if actual_group is not None and actual_group != expected_group:
+            raise EvaluationEventError(
+                f'RoboCasa task {task_index} group {actual_group!r} does not '
+                f'match {expected_group!r}')
 
     def _append_event(self, state, version, event_type, request_id, sequence,
                       payload) -> None:

--- a/fluxvla/engines/runners/serving/evaluation_reporter.py
+++ b/fluxvla/engines/runners/serving/evaluation_reporter.py
@@ -66,7 +66,7 @@ class _RunState:
     tasks_by_id: dict[str, _TaskManifestEntry]
     tasks_by_index: dict[int, _TaskManifestEntry]
     next_sequence: int = 2
-    current_episode: Optional[dict] = None
+    active_episodes: dict[tuple[int, int], dict] = field(default_factory=dict)
     episodes: list[dict] = field(default_factory=list)
     completed_keys: set[tuple[int, int]] = field(default_factory=set)
 
@@ -306,9 +306,9 @@ class FluxVLAROSEvaluationReporter:
                 raise EvaluationEventError(
                     f'run_start sequence must be 1, got {sequence}')
             state = self._start_run(run_session_id, payload)
-            self._active = state
             self._append_event(state, version, event_type, request_id,
                                sequence, payload)
+            self._active = state
             response = self._response(state, status='running')
         else:
             state = self._active
@@ -321,21 +321,31 @@ class FluxVLAROSEvaluationReporter:
             if sequence != state.next_sequence:
                 raise EvaluationEventError(
                     f'expected sequence {state.next_sequence}, got {sequence}')
-            if event_type == 'episode_start':
-                self._episode_start(state, payload)
-                status = 'running'
-            elif event_type == 'episode_end':
-                self._episode_end(state, payload)
-                status = 'running'
-            else:
-                status = self._run_end(state, payload)
-                # Local finalization is intentionally completed before the
-                # run_end event is committed. All local writes are idempotent,
-                # so a transient filesystem failure can safely retry the same
-                # request and sequence without duplicating a Feishu row.
-                summary_path = self._write_summary_artifacts(state)
-            self._append_event(state, version, event_type, request_id,
-                               sequence, payload)
+            snapshot = self._snapshot_mutable_state(state)
+            try:
+                if event_type == 'episode_start':
+                    self._episode_start(state, payload)
+                    status = 'running'
+                elif event_type == 'episode_end':
+                    self._episode_end(state, payload)
+                    status = 'running'
+                else:
+                    status = self._run_end(state, payload)
+                    # Local finalization is intentionally completed before
+                    # the run_end event is committed. All local writes are
+                    # idempotent, so a transient filesystem failure can safely
+                    # retry the same request and sequence without duplicating
+                    # a Feishu row.
+                    summary_path = self._write_summary_artifacts(state)
+                self._append_event(state, version, event_type, request_id,
+                                   sequence, payload)
+            except Exception:
+                # Event handlers update in-memory progress before the durable
+                # journal append. Restore it when either an artifact write or
+                # the journal commit fails, so the same request/sequence can
+                # be retried without observing a half-accepted episode.
+                self._restore_mutable_state(state, snapshot)
+                raise
             state.next_sequence += 1
             response = self._response(state, status=status)
             if event_type == 'run_end':
@@ -350,6 +360,22 @@ class FluxVLAROSEvaluationReporter:
         self._requests[request_id] = _CachedRequest(
             fingerprint=fingerprint, response=copy.deepcopy(response))
         return response
+
+    @staticmethod
+    def _snapshot_mutable_state(state: _RunState) -> tuple[dict, int, set]:
+        return (
+            copy.deepcopy(state.active_episodes),
+            len(state.episodes),
+            set(state.completed_keys),
+        )
+
+    @staticmethod
+    def _restore_mutable_state(state: _RunState, snapshot: tuple[dict, int,
+                                                                 set]) -> None:
+        active_episodes, episode_count, completed_keys = snapshot
+        state.active_episodes = active_episodes
+        del state.episodes[episode_count:]
+        state.completed_keys = completed_keys
 
     def _start_run(self, session_id: str, payload: dict) -> _RunState:
         schema_version = payload.get('schema_version')
@@ -460,8 +486,6 @@ class FluxVLAROSEvaluationReporter:
         return state
 
     def _episode_start(self, state: _RunState, payload: dict) -> None:
-        if state.current_episode is not None:
-            raise EvaluationEventError('an episode is already active')
         task, episode_index, seed, description = self._episode_identity(
             state, payload)
         started_at, started_epoch = _require_datetime(
@@ -469,7 +493,17 @@ class FluxVLAROSEvaluationReporter:
         key = (task.task_index, episode_index)
         if key in state.completed_keys:
             raise EvaluationEventError(f'episode {key} already completed')
-        state.current_episode = {
+        if key in state.active_episodes:
+            raise EvaluationEventError(f'episode {key} is already active')
+        episode_id = payload.get('episode_id')
+        if episode_id is not None:
+            episode_id = _require_string(episode_id, 'payload.episode_id')
+            if any(
+                    active.get('episode_id') == episode_id
+                    for active in state.active_episodes.values()):
+                raise EvaluationEventError(
+                    f'episode_id {episode_id!r} is already active')
+        current = {
             'task_id': task.task_id,
             'task_index': task.task_index,
             'description': description,
@@ -478,6 +512,9 @@ class FluxVLAROSEvaluationReporter:
             'started_at': started_at,
             'started_epoch': started_epoch,
         }
+        if episode_id is not None:
+            current['episode_id'] = episode_id
+        state.active_episodes[key] = current
         self._append_log(
             state,
             f'Evaluating Task {task.task_index}, Trial {episode_index}\n'
@@ -488,12 +525,24 @@ class FluxVLAROSEvaluationReporter:
         self._log(f'Starting episode {episode_index + 1}...')
 
     def _episode_end(self, state: _RunState, payload: dict) -> None:
-        current = state.current_episode
-        if current is None:
-            raise EvaluationEventError(
-                'episode_end has no matching episode_start')
         task, episode_index, seed, description = self._episode_identity(
             state, payload)
+        episode_key = (task.task_index, episode_index)
+        current = state.active_episodes.get(episode_key)
+        if current is None:
+            raise EvaluationEventError(
+                f'episode_end has no matching episode_start for '
+                f'episode {episode_key}')
+        episode_id = payload.get('episode_id')
+        current_episode_id = current.get('episode_id')
+        if current_episode_id is not None:
+            episode_id = _require_string(episode_id, 'payload.episode_id')
+            if episode_id != current_episode_id:
+                raise EvaluationEventError(
+                    'episode_end episode_id does not match episode_start')
+        elif episode_id is not None:
+            episode_id = _require_string(episode_id, 'payload.episode_id')
+            current['episode_id'] = episode_id
         for key, value in (
             ('task_index', task.task_index),
             ('episode_index', episode_index),
@@ -544,8 +593,8 @@ class FluxVLAROSEvaluationReporter:
             'prediction_metadata': prediction_metadata,
         }
         state.episodes.append(result)
-        state.completed_keys.add((task.task_index, episode_index))
-        state.current_episode = None
+        state.completed_keys.add(episode_key)
+        del state.active_episodes[episode_key]
         successes = sum(bool(item['success']) for item in state.episodes)
         success_rate = successes / len(state.episodes) * 100
         _write_json_atomic(state.run_dir / 'rank_progress' / 'rank0.json', {
@@ -594,9 +643,10 @@ class FluxVLAROSEvaluationReporter:
         if status not in {'finished', 'failed', 'interrupted'}:
             raise EvaluationEventError(
                 'payload.status must be finished, failed, or interrupted')
-        if status == 'finished' and state.current_episode is not None:
+        if status == 'finished' and state.active_episodes:
             raise EvaluationEventError(
-                'finished run still has an active episode')
+                'finished run still has active episodes: '
+                f'{sorted(state.active_episodes)}')
         full_suite = _require_bool(
             payload.get('full_suite'), 'payload.full_suite')
         completed = _require_int(
@@ -614,7 +664,7 @@ class FluxVLAROSEvaluationReporter:
             raise EvaluationEventError('run_end full_suite changed during run')
         if 'error' in payload:
             json.dumps(payload['error'], ensure_ascii=False)
-        state.current_episode = None
+        state.active_episodes.clear()
         self._append_log(
             state, f'Run status: {status}\n'
             f'# episodes completed: {completed}\n'
@@ -928,11 +978,24 @@ class FluxVLAROSEvaluationReporter:
             'recorded_at': datetime.now().astimezone().isoformat(),
             'payload': payload,
         }
-        with (state.run_dir / 'events.jsonl').open(
-                'a', encoding='utf-8') as stream:
-            stream.write(json.dumps(record, ensure_ascii=False) + '\n')
-            stream.flush()
-            os.fsync(stream.fileno())
+        journal_path = state.run_dir / 'events.jsonl'
+        journal_existed = journal_path.exists()
+        original_size = journal_path.stat().st_size if journal_existed else 0
+        try:
+            with journal_path.open('a', encoding='utf-8') as stream:
+                stream.write(json.dumps(record, ensure_ascii=False) + '\n')
+                stream.flush()
+                os.fsync(stream.fileno())
+        except Exception:
+            try:
+                if journal_existed:
+                    os.truncate(journal_path, original_size)
+                else:
+                    journal_path.unlink(missing_ok=True)
+            except OSError as rollback_error:
+                self._log('[ros-eval] failed to roll back journal append: '
+                          f'{rollback_error}')
+            raise
 
     @staticmethod
     def _append_log(state: _RunState, message: str) -> None:

--- a/fluxvla/engines/runners/serving/ros2_server.py
+++ b/fluxvla/engines/runners/serving/ros2_server.py
@@ -1,0 +1,107 @@
+# Copyright 2026 Limx Dynamics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Native ROS 2 transport for the FluxThemis inference service.
+
+ROS 2 dependencies are imported only by :meth:`FluxVLAROS2Server.run`.  The
+policy, request validation, episode tracking, preprocessing, and action
+denormalization contracts remain shared with the ROS 1 implementation.
+"""
+from __future__ import annotations
+import importlib
+from typing import Any
+
+from .ros_server import FluxVLAROSServer
+
+
+class _ROS2Time:
+    """Expose the ROS 1-style ``Time.now`` hook used by the shared handler."""
+
+    def __init__(self, node: Any) -> None:
+        self._node = node
+
+    def now(self) -> Any:
+        return self._node.get_clock().now().to_msg()
+
+
+class _ROS2Runtime:
+    """Small adapter for the transport-neutral request handler."""
+
+    def __init__(self, node: Any) -> None:
+        self._node = node
+        self.Time = _ROS2Time(node)
+
+    def logerr(self, message: str) -> None:
+        self._node.get_logger().error(message)
+
+
+class FluxVLAROS2Server(FluxVLAROSServer):
+    """Expose :class:`FluxVLAROSPolicy` as a native ROS 2 service."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._rclpy = None
+        self._node = None
+        self._owns_rclpy_context = False
+
+    def run(self) -> None:
+        """Import ROS 2, advertise the service, and block in ``rclpy.spin``."""
+        try:
+            rclpy = importlib.import_module('rclpy')
+            cv_bridge = importlib.import_module('cv_bridge')
+            service_module = importlib.import_module('fluxthemis_msgs.srv')
+            bridge = getattr(cv_bridge, 'CvBridge')()
+            service_type = getattr(service_module, 'PredictAction')
+            response_type = getattr(service_type, 'Response')
+        except (ImportError, AttributeError) as exc:
+            raise ImportError(
+                'FluxVLA ROS 2 serving requires rclpy, cv_bridge and the '
+                'generated fluxthemis_msgs/PredictAction service. Source the '
+                'ROS 2 installation and interface workspace before launching '
+                'the server.') from exc
+
+        owns_context = not rclpy.ok()
+        node = None
+        service = None
+        if owns_context:
+            rclpy.init(args=None)
+        try:
+            node = rclpy.create_node(self.node_name)
+            runtime = _ROS2Runtime(node)
+            self._rclpy = rclpy
+            self._node = node
+            self._owns_rclpy_context = owns_context
+            self._bind_ros(runtime, bridge, response_type)
+            service = node.create_service(service_type, self.service_name,
+                                          self._handle_ros2_request)
+            self._service = service
+            node.get_logger().info(
+                f'FluxVLA ROS 2 inference ready on {self.service_name}')
+            rclpy.spin(node)
+        finally:
+            if node is not None:
+                if service is not None:
+                    node.destroy_service(service)
+                node.destroy_node()
+            self._service = None
+            self._node = None
+            self._rclpy = None
+            self._owns_rclpy_context = False
+            self._rospy = None
+            self._bridge = None
+            self._response_type = None
+            if owns_context and rclpy.ok():
+                rclpy.shutdown()
+
+    def _handle_ros2_request(self, request: Any, response: Any) -> Any:
+        return self.handle_request(request, response=response)

--- a/fluxvla/engines/runners/serving/ros2_server.py
+++ b/fluxvla/engines/runners/serving/ros2_server.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Native ROS 2 transport for the FluxThemis inference service.
+"""Native ROS 2 transport for FluxThemis inference and reporting services.
 
 ROS 2 dependencies are imported only by :meth:`FluxVLAROS2Server.run`.  The
 policy, request validation, episode tracking, preprocessing, and action
@@ -44,9 +44,12 @@ class _ROS2Runtime:
     def logerr(self, message: str) -> None:
         self._node.get_logger().error(message)
 
+    def loginfo(self, message: str) -> None:
+        self._node.get_logger().info(message)
+
 
 class FluxVLAROS2Server(FluxVLAROSServer):
-    """Expose :class:`FluxVLAROSPolicy` as a native ROS 2 service."""
+    """Expose policy inference and optional evaluation reporting over ROS 2."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -70,9 +73,24 @@ class FluxVLAROS2Server(FluxVLAROSServer):
                 'ROS 2 installation and interface workspace before launching '
                 'the server.') from exc
 
+        report_service_type = None
+        report_response_type = None
+        if self.report_service_name is not None:
+            try:
+                report_service_type = getattr(service_module,
+                                              'ReportEvaluation')
+                report_response_type = getattr(report_service_type, 'Response')
+            except AttributeError as exc:
+                raise ImportError(
+                    'FluxVLA evaluation reporting is configured, but the '
+                    'generated fluxthemis_msgs/srv/ReportEvaluation ROS 2 '
+                    'service is unavailable. Rebuild and source the '
+                    'FluxThemis ROS 2 interface workspace.') from exc
+
         owns_context = not rclpy.ok()
         node = None
         service = None
+        report_service = None
         if owns_context:
             rclpy.init(args=None)
         try:
@@ -81,27 +99,49 @@ class FluxVLAROS2Server(FluxVLAROSServer):
             self._rclpy = rclpy
             self._node = node
             self._owns_rclpy_context = owns_context
-            self._bind_ros(runtime, bridge, response_type)
+            self._bind_ros(
+                runtime,
+                bridge,
+                response_type,
+                report_response_type=report_response_type,
+            )
             service = node.create_service(service_type, self.service_name,
                                           self._handle_ros2_request)
             self._service = service
             node.get_logger().info(
                 f'FluxVLA ROS 2 inference ready on {self.service_name}')
+            if self.report_service_name is not None:
+                report_service = node.create_service(
+                    report_service_type,
+                    self.report_service_name,
+                    self._handle_ros2_report_request,
+                )
+                self._report_service = report_service
+                node.get_logger().info(
+                    'FluxVLA ROS 2 evaluation reporting ready on '
+                    f'{self.report_service_name}')
             rclpy.spin(node)
         finally:
             if node is not None:
+                if report_service is not None:
+                    node.destroy_service(report_service)
                 if service is not None:
                     node.destroy_service(service)
                 node.destroy_node()
             self._service = None
+            self._report_service = None
             self._node = None
             self._rclpy = None
             self._owns_rclpy_context = False
             self._rospy = None
             self._bridge = None
             self._response_type = None
+            self._report_response_type = None
             if owns_context and rclpy.ok():
                 rclpy.shutdown()
 
     def _handle_ros2_request(self, request: Any, response: Any) -> Any:
         return self.handle_request(request, response=response)
+
+    def _handle_ros2_report_request(self, request: Any, response: Any) -> Any:
+        return self.handle_report_request(request, response=response)

--- a/fluxvla/engines/runners/serving/ros2_server.py
+++ b/fluxvla/engines/runners/serving/ros2_server.py
@@ -58,7 +58,7 @@ class FluxVLAROS2Server(FluxVLAROSServer):
         self._owns_rclpy_context = False
 
     def run(self) -> None:
-        """Import ROS 2, advertise the service, and block in ``rclpy.spin``."""
+        """Advertise services on a multithreaded ROS 2 executor."""
         try:
             rclpy = importlib.import_module('rclpy')
             cv_bridge = importlib.import_module('cv_bridge')
@@ -87,10 +87,24 @@ class FluxVLAROS2Server(FluxVLAROSServer):
                     'service is unavailable. Rebuild and source the '
                     'FluxThemis ROS 2 interface workspace.') from exc
 
+        try:
+            callback_groups = importlib.import_module('rclpy.callback_groups')
+            executors = importlib.import_module('rclpy.executors')
+            reentrant_group_type = getattr(callback_groups,
+                                           'ReentrantCallbackGroup')
+            exclusive_group_type = getattr(callback_groups,
+                                           'MutuallyExclusiveCallbackGroup')
+            executor_type = getattr(executors, 'MultiThreadedExecutor')
+        except (ImportError, AttributeError) as exc:
+            raise ImportError(
+                'FluxVLA multi-worker ROS 2 serving requires '
+                'rclpy.callback_groups and rclpy.executors.') from exc
+
         owns_context = not rclpy.ok()
         node = None
         service = None
         report_service = None
+        executor = None
         if owns_context:
             rclpy.init(args=None)
         try:
@@ -105,23 +119,46 @@ class FluxVLAROS2Server(FluxVLAROSServer):
                 response_type,
                 report_response_type=report_response_type,
             )
-            service = node.create_service(service_type, self.service_name,
-                                          self._handle_ros2_request)
+            prediction_group = reentrant_group_type()
+            report_group = exclusive_group_type()
+            service = node.create_service(
+                service_type,
+                self.service_name,
+                self._handle_ros2_request,
+                callback_group=prediction_group,
+            )
             self._service = service
             node.get_logger().info(
                 f'FluxVLA ROS 2 inference ready on {self.service_name}')
+            worker_count = int(getattr(self.policy, 'worker_count', 1))
+            if worker_count > 1:
+                devices = ', '.join(getattr(self.policy, 'worker_devices', ()))
+                node.get_logger().info(
+                    f'FluxVLA inference pool: {worker_count} '
+                    f'episode-affine replicas on {devices}')
             if self.report_service_name is not None:
                 report_service = node.create_service(
                     report_service_type,
                     self.report_service_name,
                     self._handle_ros2_report_request,
+                    callback_group=report_group,
                 )
                 self._report_service = report_service
                 node.get_logger().info(
                     'FluxVLA ROS 2 evaluation reporting ready on '
                     f'{self.report_service_name}')
-            rclpy.spin(node)
+            executor_threads = (
+                self.executor_threads if self.executor_threads is not None else
+                max(32, worker_count + 1))
+            executor = executor_type(num_threads=executor_threads)
+            executor.add_node(node)
+            executor.spin()
         finally:
+            if executor is not None:
+                try:
+                    executor.remove_node(node)
+                finally:
+                    executor.shutdown(timeout_sec=5.0)
             if node is not None:
                 if report_service is not None:
                     node.destroy_service(report_service)

--- a/fluxvla/engines/runners/serving/ros_server.py
+++ b/fluxvla/engines/runners/serving/ros_server.py
@@ -321,10 +321,11 @@ class FluxVLAROSServer:
     """Expose policy inference and optional evaluation reporting over ROS 1."""
 
     def __init__(self,
-                 policy: FluxVLAROSPolicy,
+                 policy: Any,
                  transport: Mapping[str, Any],
                  evaluation_reporter: Any = None,
-                 node_name: str = 'fluxvla_inference_server') -> None:
+                 node_name: str = 'fluxvla_inference_server',
+                 executor_threads: int | None = None) -> None:
         if not isinstance(transport, Mapping):
             raise TypeError('themis.transport must be a mapping')
         self.policy = policy
@@ -349,6 +350,13 @@ class FluxVLAROSServer:
                 'themis.transport.report_service_name and an evaluation '
                 'reporter must be configured together')
         self.node_name = self._nonempty_string(node_name, 'node_name')
+        if (executor_threads is not None
+                and (isinstance(executor_threads, bool)
+                     or not isinstance(executor_threads, int))):
+            raise TypeError('executor_threads must be an integer or None')
+        if executor_threads is not None and executor_threads < 2:
+            raise ValueError('executor_threads must be at least 2')
+        self.executor_threads = executor_threads
         self.evaluation_reporter = evaluation_reporter
 
         self._rospy = None
@@ -403,6 +411,12 @@ class FluxVLAROSServer:
         self._service = rospy.Service(self.service_name, service_type,
                                       self.handle_request)
         rospy.loginfo(f'FluxVLA ROS inference ready on {self.service_name}')
+        worker_count = getattr(self.policy, 'worker_count', 1)
+        if worker_count > 1:
+            devices = ', '.join(getattr(self.policy, 'worker_devices', ()))
+            rospy.loginfo(
+                f'FluxVLA inference pool: {worker_count} episode-affine '
+                f'replicas on {devices}')
         if self.report_service_name is not None:
             self._report_service = rospy.Service(
                 self.report_service_name,
@@ -439,17 +453,27 @@ class FluxVLAROSServer:
         response.request_id = request_id
         response.header.stamp = self._rospy.Time.now()
         try:
-            with self._request_lock:
-                observation, episode_id, seed, unnorm_key = \
-                    self._decode_request(request)
-                is_new_episode = (
-                    bool(request.reset) or episode_id != self._last_episode_id
-                    or seed != self._last_seed)
-                observation['is_new_episode'] = is_new_episode
+            observation, episode_id, seed, unnorm_key = \
+                self._decode_request(request)
+            if getattr(self.policy, 'supports_episode_affinity', False):
                 actions, inference_time_s = self.policy.predict(
-                    observation, unnorm_key=unnorm_key, seed=seed)
-                self._last_episode_id = episode_id
-                self._last_seed = seed
+                    observation,
+                    unnorm_key=unnorm_key,
+                    seed=seed,
+                    episode_id=episode_id,
+                    reset=bool(request.reset),
+                )
+            else:
+                with self._request_lock:
+                    is_new_episode = (
+                        bool(request.reset)
+                        or episode_id != self._last_episode_id
+                        or seed != self._last_seed)
+                    observation['is_new_episode'] = is_new_episode
+                    actions, inference_time_s = self.policy.predict(
+                        observation, unnorm_key=unnorm_key, seed=seed)
+                    self._last_episode_id = episode_id
+                    self._last_seed = seed
 
             response.ok = True
             response.error = ''
@@ -489,6 +513,8 @@ class FluxVLAROSServer:
         try:
             with self._report_lock:
                 event = self._decode_report_request(request)
+                self._validate_parallel_capacity(event)
+                affinity_episode_id = self._affinity_release_target(event)
                 result = self.evaluation_reporter.process_event(
                     event_type=event['event_type'],
                     request_id=event['request_id'],
@@ -496,10 +522,16 @@ class FluxVLAROSServer:
                     sequence=event['sequence'],
                     payload=event['payload'],
                 )
-            if not isinstance(result, Mapping):
-                raise TypeError(
-                    'Evaluation reporter process_event() must return a '
-                    'mapping')
+                if not isinstance(result, Mapping):
+                    raise TypeError(
+                        'Evaluation reporter process_event() must return a '
+                        'mapping')
+                if bool(result.get('accepted', False)):
+                    if affinity_episode_id is not None:
+                        self.policy.release_episode(affinity_episode_id)
+                    elif (event['event_type'] == 'run_end' and getattr(
+                            self.policy, 'supports_episode_affinity', False)):
+                        self.policy.release_all()
             response.accepted = bool(result.get('accepted', False))
             response.error = str(result.get('error') or '')
             response.run_dir = str(result.get('run_dir') or '')
@@ -518,6 +550,50 @@ class FluxVLAROSServer:
                        f'{request_id or "<missing>"} rejected: '
                        f'{response.error}')
         return response
+
+    def close(self) -> None:
+        """Release inference workers owned by this server."""
+        close = getattr(self.policy, 'close', None)
+        if callable(close):
+            close()
+
+    def _affinity_release_target(self, event: Mapping[str, Any]) -> str | None:
+        if not getattr(self.policy, 'supports_episode_affinity', False):
+            return None
+        if event.get('event_type') != 'episode_end':
+            return None
+        payload = event.get('payload')
+        if not isinstance(payload, Mapping):
+            raise TypeError('episode_end payload must be a mapping')
+        episode_id = payload.get('episode_id')
+        return self._nonempty_string(
+            episode_id,
+            'episode_end payload.episode_id',
+        )
+
+    def _validate_parallel_capacity(self, event: Mapping[str, Any]) -> None:
+        if (event.get('event_type') != 'run_start' or
+                not getattr(self.policy, 'supports_episode_affinity', False)):
+            return
+        payload = event.get('payload')
+        if not isinstance(payload, Mapping):
+            raise TypeError('run_start payload must be a mapping')
+        requested = payload.get('parallel_workers', 1)
+        if isinstance(requested,
+                      bool) or not isinstance(requested, (int, np.integer)):
+            raise TypeError(
+                'run_start payload.parallel_workers must be an integer')
+        requested = int(requested)
+        if requested < 1:
+            raise ValueError(
+                'run_start payload.parallel_workers must be positive')
+        available = int(getattr(self.policy, 'worker_count', 1))
+        if requested > available:
+            raise ValueError(
+                f'FluxThemis requested {requested} parallel simulator '
+                f'workers, but FluxVLA has only {available} episode-affine '
+                'inference replicas. Start FluxVLA with at least '
+                f'--num-workers {requested}, or reduce FluxThemis --workers.')
 
     def _decode_report_request(self, request: Any) -> dict[str, Any]:
         request_id = self._nonempty_string(
@@ -649,19 +725,12 @@ class FluxVLAROSServer:
         return value
 
 
-def build_ros_server_from_config(
+def build_ros_policy_from_config(
         cfg: Any,
         ckpt_path: str | None = None,
         device: str | None = None,
-        service_name: str | None = None,
-        node_name: str | None = None,
-        ros_version: int | str | None = None,
-        config_path: str | os.PathLike | None = None) -> FluxVLAROSServer:
-    """Build a ROS 1 or ROS 2 server from one FluxVLA configuration.
-
-    ``ros_version`` overrides ``themis.ros_server.ros_version``.  ROS 1 stays
-    the default so existing launch commands and configurations are unchanged.
-    """
+        service_name: str | None = None) -> FluxVLAROSPolicy:
+    """Build one complete policy replica from an authoritative config."""
     themis_cfg = _require_mapping(
         _config_get(cfg, 'themis', _MISSING), 'config.themis')
     transport = dict(
@@ -670,10 +739,6 @@ def build_ros_server_from_config(
     server_cfg = dict(
         _require_mapping(
             themis_cfg.get('ros_server', _MISSING), 'themis.ros_server'))
-    configured_ros_version = server_cfg.get('ros_version', 1)
-    requested_ros_version = (
-        configured_ros_version if ros_version is None else ros_version)
-    resolved_ros_version = _resolve_ros_version(requested_ros_version)
     if service_name is not None:
         transport['service_name'] = service_name
 
@@ -687,7 +752,6 @@ def build_ros_server_from_config(
         _require_mapping(
             section_cfg.get('dataset', _MISSING),
             f'config.{section_name}.dataset'))
-
     resolved_ckpt = _resolve_checkpoint_path(
         ckpt_path or server_cfg.get('ckpt_path')
         or section_cfg.get('ckpt_path'))
@@ -742,7 +806,7 @@ def build_ros_server_from_config(
 
     resolved_device = device or server_cfg.get('device', 'cuda:0')
     dtype_name = server_cfg.get('mixed_precision_dtype', 'bf16')
-    policy = FluxVLAROSPolicy(
+    return FluxVLAROSPolicy(
         vla=vla,
         dataset=dataset,
         denormalize_action=denormalize_action,
@@ -754,6 +818,68 @@ def build_ros_server_from_config(
         denormalize_context=denormalize_context,
         denormalize_per_action=server_cfg.get('denormalize_per_action', False),
     )
+
+
+def build_ros_server_from_config(
+        cfg: Any,
+        ckpt_path: str | None = None,
+        device: str | None = None,
+        worker_devices: Sequence[str] | None = None,
+        num_workers: int | None = None,
+        service_name: str | None = None,
+        node_name: str | None = None,
+        ros_version: int | str | None = None,
+        config_path: str | os.PathLike | None = None) -> FluxVLAROSServer:
+    """Build a ROS 1 or ROS 2 server from one FluxVLA configuration.
+
+    ``ros_version`` overrides ``themis.ros_server.ros_version``.  ROS 1 stays
+    the default so existing launch commands and configurations are unchanged.
+    """
+    themis_cfg = _require_mapping(
+        _config_get(cfg, 'themis', _MISSING), 'config.themis')
+    transport = dict(
+        _require_mapping(
+            themis_cfg.get('transport', _MISSING), 'themis.transport'))
+    server_cfg = dict(
+        _require_mapping(
+            themis_cfg.get('ros_server', _MISSING), 'themis.ros_server'))
+    configured_ros_version = server_cfg.get('ros_version', 1)
+    requested_ros_version = (
+        configured_ros_version if ros_version is None else ros_version)
+    resolved_ros_version = _resolve_ros_version(requested_ros_version)
+    if service_name is not None:
+        transport['service_name'] = service_name
+
+    section_name = server_cfg.get('dataset_section')
+    if section_name not in {'eval', 'inference'}:
+        raise ValueError('themis.ros_server.dataset_section must be `eval` or '
+                         '`inference`')
+    section_cfg = _require_mapping(
+        _config_get(cfg, section_name, _MISSING), f'config.{section_name}')
+    resolved_ckpt = _resolve_checkpoint_path(
+        ckpt_path or server_cfg.get('ckpt_path')
+        or section_cfg.get('ckpt_path'))
+    stats_path = _resolve_statistics_path(
+        server_cfg.get('norm_stats_path'), resolved_ckpt)
+    model_outputs_environment_actions = server_cfg.get(
+        'model_outputs_environment_actions', False)
+    if not model_outputs_environment_actions and stats_path is None:
+        raise FileNotFoundError(
+            'dataset_statistics.json is required to prove the ROS action '
+            'unit contract')
+    resolved_devices = _resolve_inference_devices(
+        server_cfg=server_cfg,
+        device=device,
+        worker_devices=worker_devices,
+        num_workers=num_workers,
+    )
+    resolved_device = resolved_devices[0]
+    if (len(resolved_devices) > 1
+            and transport.get('report_service_name') is None):
+        raise ValueError(
+            'Multi-worker ROS inference requires '
+            'themis.transport.report_service_name so episode affinity can be '
+            'released after acknowledged episode_end events')
     evaluation_reporter = None
     if transport.get('report_service_name') is not None:
         reporting_cfg = _require_mapping(
@@ -802,17 +928,127 @@ def build_ros_server_from_config(
             logger=None,
             feishu=reporting_cfg.get('feishu'),
         )
-    server_type = FluxVLAROSServer
-    if resolved_ros_version == 2:
-        from .ros2_server import FluxVLAROS2Server
-        server_type = FluxVLAROS2Server
-    return server_type(
-        policy=policy,
-        transport=transport,
-        evaluation_reporter=evaluation_reporter,
-        node_name=node_name
-        or server_cfg.get('node_name', 'fluxvla_inference_server'),
+
+    workers_cfg = dict(
+        _require_mapping(
+            server_cfg.get('workers', {}),
+            'themis.ros_server.workers',
+        ))
+    if len(resolved_devices) == 1:
+        direct_policy = build_ros_policy_from_config(
+            cfg,
+            ckpt_path=str(resolved_ckpt),
+            device=resolved_device,
+            service_name=transport.get('service_name'),
+        )
+        if transport.get('report_service_name') is None:
+            policy = direct_policy
+        else:
+            # Reporting supplies the durable episode_end signal.  Use the
+            # same affinity contract for one replica so concurrent simulator
+            # clients cannot interleave stateful policy history.
+            from .ros_worker_pool import EpisodeAffinityPolicyPool
+            policy = EpisodeAffinityPolicyPool(
+                backends=[direct_policy],
+                lease_timeout_s=workers_cfg.get('lease_timeout_s', 900.0),
+            )
+    else:
+        from .ros_worker_pool import spawn_ros_policy_pool
+        policy = spawn_ros_policy_pool(
+            cfg=cfg,
+            ckpt_path=str(resolved_ckpt),
+            devices=resolved_devices,
+            service_name=transport.get('service_name'),
+            startup_timeout_s=workers_cfg.get('startup_timeout_s', 900.0),
+            request_timeout_s=workers_cfg.get('request_timeout_s', 120.0),
+            lease_timeout_s=workers_cfg.get('lease_timeout_s', 900.0),
+        )
+    try:
+        server_type = FluxVLAROSServer
+        if resolved_ros_version == 2:
+            from .ros2_server import FluxVLAROS2Server
+            server_type = FluxVLAROS2Server
+        return server_type(
+            policy=policy,
+            transport=transport,
+            evaluation_reporter=evaluation_reporter,
+            node_name=node_name
+            or server_cfg.get('node_name', 'fluxvla_inference_server'),
+            executor_threads=server_cfg.get('executor_threads'),
+        )
+    except BaseException:
+        close = getattr(policy, 'close', None)
+        if callable(close):
+            close()
+        raise
+
+
+def _resolve_inference_devices(server_cfg: Mapping[str,
+                                                   Any], device: str | None,
+                               worker_devices: Sequence[str] | None,
+                               num_workers: int | None) -> tuple[str, ...]:
+    """Resolve CLI/config worker devices while preserving legacy defaults."""
+    workers_cfg = _require_mapping(
+        server_cfg.get('workers', {}),
+        'themis.ros_server.workers',
     )
+    if worker_devices is not None and num_workers is not None:
+        raise ValueError(
+            'worker_devices and num_workers are mutually exclusive')
+
+    values: Any
+    if worker_devices is not None:
+        values = worker_devices
+    elif num_workers is not None:
+        count = _positive_worker_count(num_workers, 'num_workers')
+        if count == 1:
+            values = [device or server_cfg.get('device', 'cuda:0')]
+        else:
+            if device is not None:
+                raise ValueError(
+                    '--device cannot be combined with --num-workers greater '
+                    'than one; use --devices for explicit placement')
+            values = [f'cuda:{index}' for index in range(count)]
+    elif device is not None:
+        values = [device]
+    elif workers_cfg.get('devices') is not None:
+        values = workers_cfg['devices']
+    elif workers_cfg.get('num_workers') is not None:
+        count = _positive_worker_count(
+            workers_cfg['num_workers'],
+            'themis.ros_server.workers.num_workers',
+        )
+        values = [f'cuda:{index}' for index in range(count)]
+    else:
+        values = [server_cfg.get('device', 'cuda:0')]
+
+    if isinstance(values, (str, bytes)) or not isinstance(values, Sequence):
+        raise TypeError('inference worker devices must be a sequence')
+    if not values:
+        raise ValueError('inference worker devices cannot be empty')
+    normalized = []
+    for index, value in enumerate(values):
+        if not isinstance(value, str) or not value.strip():
+            raise TypeError(
+                f'inference worker device {index} must be a non-empty string')
+        value = value.strip()
+        try:
+            torch.device(value)
+        except (RuntimeError, TypeError) as exc:
+            raise ValueError(
+                f'Invalid inference worker device {value!r}') from exc
+        normalized.append(value)
+    if len(normalized) != len(set(normalized)):
+        raise ValueError('inference worker devices cannot contain duplicates')
+    return tuple(normalized)
+
+
+def _positive_worker_count(value: Any, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f'{name} must be an integer')
+    if value <= 0:
+        raise ValueError(f'{name} must be positive')
+    return value
 
 
 def _resolve_ros_version(value: Any) -> int:

--- a/fluxvla/engines/runners/serving/ros_server.py
+++ b/fluxvla/engines/runners/serving/ros_server.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""ROS inference service used by FluxThemis.
+"""ROS inference and evaluation-report services used by FluxThemis.
 
 ROS imports are intentionally delayed until :meth:`FluxVLAROSServer.run` so
 normal FluxVLA training and evaluation do not require a sourced ROS workspace.
@@ -57,13 +57,13 @@ class _RawImageBridge:
                 f'{type(message).__name__}')
         if desired_encoding not in self._SUPPORTED_ENCODINGS:
             raise ValueError(
-                f'Unsupported desired image encoding {desired_encoding!r}; '
+                f'Unsupported desired image encoding {desired_encoding!r}: '
                 'expected rgb8 or bgr8')
 
         encoding = getattr(message, 'encoding', None)
         if encoding not in self._SUPPORTED_ENCODINGS:
             raise ValueError(
-                f'Unsupported ROS image encoding {encoding!r}; expected '
+                f'Unsupported ROS image encoding {encoding!r}: expected '
                 'rgb8 or bgr8')
         if encoding != desired_encoding:
             raise ValueError(
@@ -86,7 +86,7 @@ class _RawImageBridge:
         expected_size = height * step
         if len(payload) != expected_size:
             raise ValueError(
-                f'ROS image data has {len(payload)} bytes; expected exactly '
+                f'ROS image data has {len(payload)} bytes, expected exactly '
                 f'{expected_size} for height={height} and step={step}')
 
         rows = np.frombuffer(payload, dtype=np.uint8).reshape(height, step)
@@ -318,11 +318,12 @@ class FluxVLAROSPolicy:
 
 
 class FluxVLAROSServer:
-    """Lazy-ROS wrapper exposing :class:`FluxVLAROSPolicy` as a service."""
+    """Expose policy inference and optional evaluation reporting over ROS 1."""
 
     def __init__(self,
                  policy: FluxVLAROSPolicy,
                  transport: Mapping[str, Any],
+                 evaluation_reporter: Any = None,
                  node_name: str = 'fluxvla_inference_server') -> None:
         if not isinstance(transport, Mapping):
             raise TypeError('themis.transport must be a mapping')
@@ -337,13 +338,27 @@ class FluxVLAROSServer:
         self.image_encoding = self._nonempty_string(
             transport.get('image_encoding', 'rgb8'),
             'themis.transport.image_encoding')
+        configured_report_service = transport.get('report_service_name')
+        self.report_service_name = None
+        if configured_report_service is not None:
+            self.report_service_name = self._nonempty_string(
+                configured_report_service,
+                'themis.transport.report_service_name')
+        if (self.report_service_name is None) != (evaluation_reporter is None):
+            raise ValueError(
+                'themis.transport.report_service_name and an evaluation '
+                'reporter must be configured together')
         self.node_name = self._nonempty_string(node_name, 'node_name')
+        self.evaluation_reporter = evaluation_reporter
 
         self._rospy = None
         self._bridge = None
         self._response_type = None
+        self._report_response_type = None
         self._service = None
+        self._report_service = None
         self._request_lock = threading.RLock()
+        self._report_lock = threading.RLock()
         self._last_episode_id: str | None = None
         self._last_seed: int | None = None
 
@@ -363,18 +378,56 @@ class FluxVLAROSServer:
                 'Source the ROS 1 workspace before launching the server.') \
                 from exc
 
+        report_service_type = None
+        report_response_type = None
+        if self.report_service_name is not None:
+            try:
+                report_service_type = getattr(service_module,
+                                              'ReportEvaluation')
+                report_response_type = getattr(service_module,
+                                               'ReportEvaluationResponse')
+            except AttributeError as exc:
+                raise ImportError(
+                    'FluxVLA evaluation reporting is configured, but the '
+                    'generated fluxthemis_msgs/ReportEvaluation ROS 1 service '
+                    'is unavailable. Rebuild and source the FluxThemis ROS 1 '
+                    'interface workspace.') from exc
+
         rospy.init_node(self.node_name, anonymous=False)
-        self._bind_ros(rospy, bridge, response_type)
+        self._bind_ros(
+            rospy,
+            bridge,
+            response_type,
+            report_response_type=report_response_type,
+        )
         self._service = rospy.Service(self.service_name, service_type,
                                       self.handle_request)
         rospy.loginfo(f'FluxVLA ROS inference ready on {self.service_name}')
+        if self.report_service_name is not None:
+            self._report_service = rospy.Service(
+                self.report_service_name,
+                report_service_type,
+                self.handle_report_request,
+            )
+            rospy.loginfo('FluxVLA evaluation reporting ready on '
+                          f'{self.report_service_name}')
         rospy.spin()
 
-    def _bind_ros(self, rospy: Any, bridge: Any, response_type: Any) -> None:
+    def _bind_ros(self,
+                  rospy: Any,
+                  bridge: Any,
+                  response_type: Any,
+                  report_response_type: Any = None) -> None:
         """Bind generated ROS types for dependency-free tests."""
         self._rospy = rospy
         self._bridge = bridge
         self._response_type = response_type
+        self._report_response_type = report_response_type
+        if self.evaluation_reporter is not None:
+            set_logger = getattr(self.evaluation_reporter, 'set_logger', None)
+            loginfo = getattr(rospy, 'loginfo', None)
+            if callable(set_logger) and callable(loginfo):
+                set_logger(loginfo)
 
     def handle_request(self, request: Any, response: Any = None) -> Any:
         if (self._rospy is None or self._bridge is None
@@ -418,6 +471,84 @@ class FluxVLAROSServer:
                 logerr(f'FluxVLA ROS request {request_id or "<missing>"} '
                        f'failed: {response.error}')
         return response
+
+    def handle_report_request(self, request: Any, response: Any = None) -> Any:
+        """Validate and persist one environment-side evaluation event."""
+        if (self._rospy is None or self._report_response_type is None
+                or self.evaluation_reporter is None):
+            raise RuntimeError(
+                'FluxVLAROSServer evaluation reporting was not started')
+        if response is None:
+            response = self._report_response_type()
+        request_id = str(getattr(request, 'request_id', ''))
+        response.request_id = request_id
+        response.header.stamp = self._rospy.Time.now()
+        response.accepted = False
+        response.error = ''
+        response.run_dir = ''
+        try:
+            with self._report_lock:
+                event = self._decode_report_request(request)
+                result = self.evaluation_reporter.process_event(
+                    event_type=event['event_type'],
+                    request_id=event['request_id'],
+                    run_session_id=event['run_id'],
+                    sequence=event['sequence'],
+                    payload=event['payload'],
+                )
+            if not isinstance(result, Mapping):
+                raise TypeError(
+                    'Evaluation reporter process_event() must return a '
+                    'mapping')
+            response.accepted = bool(result.get('accepted', False))
+            response.error = str(result.get('error') or '')
+            response.run_dir = str(result.get('run_dir') or '')
+            if not response.accepted and not response.error:
+                response.error = 'Evaluation reporter rejected the event'
+        # ROS callbacks must always return a response.
+        except Exception as exc:
+            response.accepted = False
+            response.error = f'{type(exc).__name__}: {exc}'
+            response.run_dir = ''
+
+        if not response.accepted:
+            logerr = getattr(self._rospy, 'logerr', None)
+            if callable(logerr):
+                logerr('FluxVLA evaluation report '
+                       f'{request_id or "<missing>"} rejected: '
+                       f'{response.error}')
+        return response
+
+    def _decode_report_request(self, request: Any) -> dict[str, Any]:
+        request_id = self._nonempty_string(
+            getattr(request, 'request_id', ''), 'request.request_id')
+        run_id = self._nonempty_string(
+            getattr(request, 'run_id', ''), 'request.run_id')
+        event_type = self._nonempty_string(
+            getattr(request, 'event_type', ''), 'request.event_type')
+        sequence = getattr(request, 'sequence', None)
+        if (isinstance(sequence, bool)
+                or not isinstance(sequence, (int, np.integer))):
+            raise TypeError('request.sequence must be an integer')
+        sequence = int(sequence)
+        if sequence < 0:
+            raise ValueError('request.sequence must be non-negative')
+        payload_json = self._nonempty_string(
+            getattr(request, 'payload_json', ''), 'request.payload_json')
+        try:
+            payload = json.loads(payload_json)
+        except json.JSONDecodeError as exc:
+            raise ValueError('request.payload_json must contain valid JSON') \
+                from exc
+        if not isinstance(payload, Mapping):
+            raise TypeError('request.payload_json must encode a JSON object')
+        return {
+            'request_id': request_id,
+            'run_id': run_id,
+            'sequence': sequence,
+            'event_type': event_type,
+            'payload': dict(payload),
+        }
 
     def _decode_request(self,
                         request: Any) -> tuple[dict[str, Any], str, int, str]:
@@ -524,7 +655,8 @@ def build_ros_server_from_config(
         device: str | None = None,
         service_name: str | None = None,
         node_name: str | None = None,
-        ros_version: int | str | None = None) -> FluxVLAROSServer:
+        ros_version: int | str | None = None,
+        config_path: str | os.PathLike | None = None) -> FluxVLAROSServer:
     """Build a ROS 1 or ROS 2 server from one FluxVLA configuration.
 
     ``ros_version`` overrides ``themis.ros_server.ros_version``.  ROS 1 stays
@@ -622,6 +754,54 @@ def build_ros_server_from_config(
         denormalize_context=denormalize_context,
         denormalize_per_action=server_cfg.get('denormalize_per_action', False),
     )
+    evaluation_reporter = None
+    if transport.get('report_service_name') is not None:
+        reporting_cfg = _require_mapping(
+            server_cfg.get('evaluation_reporting', {}),
+            'themis.ros_server.evaluation_reporting',
+        )
+        resolved_config_path = _resolve_report_config_path(cfg, config_path)
+        result_root = _resolve_report_result_root(
+            reporting_cfg.get('result_output_dir'),
+            resolved_config_path,
+        )
+        reporter_eval_source = _config_get(cfg, 'eval', section_cfg)
+        reporter_eval_config = copy.deepcopy(
+            dict(
+                _require_mapping(reporter_eval_source,
+                                 'config.eval metadata')))
+        runner_cfg = themis_cfg.get('runner')
+        if isinstance(runner_cfg, Mapping):
+            if 'task_ids' in runner_cfg:
+                reporter_eval_config.setdefault('task_ids',
+                                                runner_cfg['task_ids'])
+            if 'episodes_per_task' in runner_cfg:
+                reporter_eval_config.setdefault(
+                    'num_trials_per_task', runner_cfg['episodes_per_task'])
+            if 'run_name' in runner_cfg:
+                reporter_eval_config.setdefault('run_name',
+                                                runner_cfg['run_name'])
+        reporter_eval_config.setdefault('dataset_section', section_name)
+        reporter_eval_config.setdefault('service_name',
+                                        transport.get('service_name'))
+        if 'result_gpu_id' not in reporter_eval_config:
+            configured_gpu_id = reporting_cfg.get('result_gpu_id')
+            if configured_gpu_id is None:
+                report_device = torch.device(resolved_device)
+                configured_gpu_id = (
+                    report_device.index if report_device.type == 'cuda'
+                    and report_device.index is not None else 0)
+            reporter_eval_config['result_gpu_id'] = configured_gpu_id
+
+        from .evaluation_reporter import FluxVLAROSEvaluationReporter
+        evaluation_reporter = FluxVLAROSEvaluationReporter(
+            result_root=result_root,
+            config_path=resolved_config_path,
+            ckpt_path=resolved_ckpt,
+            eval_config=reporter_eval_config,
+            logger=None,
+            feishu=reporting_cfg.get('feishu'),
+        )
     server_type = FluxVLAROSServer
     if resolved_ros_version == 2:
         from .ros2_server import FluxVLAROS2Server
@@ -629,6 +809,7 @@ def build_ros_server_from_config(
     return server_type(
         policy=policy,
         transport=transport,
+        evaluation_reporter=evaluation_reporter,
         node_name=node_name
         or server_cfg.get('node_name', 'fluxvla_inference_server'),
     )
@@ -646,6 +827,62 @@ def _resolve_ros_version(value: Any) -> int:
     if value == 2 or value == '2':
         return 2
     raise ValueError('ROS version must be 1 or 2')
+
+
+def _resolve_report_config_path(
+        cfg: Any, explicit_path: str | os.PathLike | None) -> Path:
+    value = explicit_path
+    if value is None:
+        value = getattr(cfg, 'filename', None)
+    if not isinstance(value, (str, os.PathLike)) or not str(value):
+        raise ValueError(
+            'Evaluation reporting requires the authoritative FluxVLA config '
+            'path')
+    path = Path(value).expanduser().resolve()
+    if not path.is_file():
+        raise FileNotFoundError(f'FluxVLA config not found: {path}')
+    return path
+
+
+def _resolve_report_result_root(value: Any, config_path: Path) -> Path:
+    fluxvla_root = _find_fluxvla_root(config_path)
+    work_dirs_root = (fluxvla_root / 'work_dirs').resolve()
+    if value is None:
+        candidate = work_dirs_root / 'fluxthemis'
+    else:
+        if not isinstance(value, (str, os.PathLike)) or not str(value).strip():
+            raise TypeError(
+                'themis.ros_server.evaluation_reporting.result_output_dir '
+                'must be a non-empty path')
+        requested = Path(value).expanduser()
+        if requested.is_absolute():
+            candidate = requested
+        elif requested.parts and requested.parts[0] == 'work_dirs':
+            candidate = fluxvla_root / requested
+        else:
+            candidate = work_dirs_root / requested
+    resolved = candidate.resolve()
+    try:
+        resolved.relative_to(work_dirs_root)
+    except ValueError as exc:
+        raise ValueError(
+            'Evaluation reporting artifacts must stay inside FluxVLA '
+            f'work_dirs: {work_dirs_root}') from exc
+    return resolved
+
+
+def _find_fluxvla_root(config_path: Path) -> Path:
+    for candidate in config_path.parent.parents:
+        if ((candidate / 'fluxvla' / '__init__.py').is_file()
+                and (candidate / 'configs').is_dir()):
+            try:
+                config_path.relative_to((candidate / 'configs').resolve())
+            except ValueError:
+                continue
+            return candidate.resolve()
+    raise ValueError(
+        'Evaluation reporting config must be located under a FluxVLA '
+        f'configs directory: {config_path}')
 
 
 def _resolve_checkpoint_path(value: Any) -> Path:

--- a/fluxvla/engines/runners/serving/ros_server.py
+++ b/fluxvla/engines/runners/serving/ros_server.py
@@ -116,7 +116,8 @@ class FluxVLAROSPolicy:
                  model_outputs_environment_actions: bool = False,
                  forward_seed: bool = False,
                  denormalize_context: Mapping[str, Any] | None = None,
-                 denormalize_per_action: bool = False) -> None:
+                 denormalize_per_action: bool = False,
+                 expected_unnorm_key: str = '') -> None:
         if not callable(dataset):
             raise TypeError('FluxVLA ROS server dataset must be callable')
         if (not model_outputs_environment_actions
@@ -142,6 +143,8 @@ class FluxVLAROSPolicy:
         if denormalize_context is not None and not isinstance(
                 denormalize_context, Mapping):
             raise TypeError('denormalize_context must be a mapping')
+        if not isinstance(expected_unnorm_key, str):
+            raise TypeError('expected_unnorm_key must be a string')
 
         self.vla = vla
         self.dataset = dataset
@@ -154,6 +157,7 @@ class FluxVLAROSPolicy:
         self.forward_seed = forward_seed
         self.denormalize_context = dict(denormalize_context or {})
         self.denormalize_per_action = denormalize_per_action
+        self.expected_unnorm_key = expected_unnorm_key
         self._lock = threading.RLock()
 
         if self.device.type == 'cuda':
@@ -166,6 +170,12 @@ class FluxVLAROSPolicy:
         """Preprocess one request and return environment-unit ``[T, A]``."""
         if not isinstance(observation, Mapping):
             raise TypeError('observation must be a mapping')
+        if (unnorm_key and self.expected_unnorm_key
+                and unnorm_key != self.expected_unnorm_key):
+            raise ValueError(
+                f'Request unnorm_key {unnorm_key!r} does not match the '
+                f'configured key {self.expected_unnorm_key!r}')
+        unnorm_key = unnorm_key or self.expected_unnorm_key
         with self._lock, self._seed_context(seed):
             result = self.dataset(dict(observation))
             batch = result[0] if isinstance(result, tuple) else result
@@ -775,7 +785,12 @@ def build_ros_policy_from_config(
         raise KeyError('FluxVLA config must define `model` or '
                        '`inference_model`')
     vla = build_vla_from_cfg(model_cfg)
-    _load_checkpoint(vla, resolved_ckpt)
+    checkpoint_model_cfg = _config_get(cfg, 'model', model_cfg)
+    _load_checkpoint(
+        vla,
+        resolved_ckpt,
+        name_mapping=_config_get(checkpoint_model_cfg, 'name_mapping'),
+    )
     if stats_path is not None:
         with stats_path.open('r', encoding='utf-8') as stream:
             vla.norm_stats = json.load(stream)
@@ -803,6 +818,8 @@ def build_ros_policy_from_config(
         denormalize_action = build_transform_from_cfg(denorm_cfg)
         _prepare_denormalize_context(denormalize_context, denorm_cfg,
                                      section_cfg, transport)
+        _validate_denormalization_stats(denormalize_action,
+                                        denormalize_context)
 
     resolved_device = device or server_cfg.get('device', 'cuda:0')
     dtype_name = server_cfg.get('mixed_precision_dtype', 'bf16')
@@ -817,6 +834,7 @@ def build_ros_policy_from_config(
         forward_seed=server_cfg.get('forward_seed', False),
         denormalize_context=denormalize_context,
         denormalize_per_action=server_cfg.get('denormalize_per_action', False),
+        expected_unnorm_key=str(transport.get('unnorm_key', '')),
     )
 
 
@@ -927,6 +945,7 @@ def build_ros_server_from_config(
             eval_config=reporter_eval_config,
             logger=None,
             feishu=reporting_cfg.get('feishu'),
+            report_kind=reporting_cfg.get('report_kind'),
         )
 
     workers_cfg = dict(
@@ -1127,7 +1146,7 @@ def _resolve_checkpoint_path(value: Any) -> Path:
             'Checkpoint path is required via --ckpt-path, '
             'themis.ros_server.ckpt_path, or the selected section.ckpt_path')
     path = Path(value).expanduser().resolve()
-    if not path.is_file():
+    if not path.exists() or not (path.is_file() or path.is_dir()):
         raise FileNotFoundError(f'Checkpoint not found: {path}')
     return path
 
@@ -1145,15 +1164,58 @@ def _resolve_statistics_path(value: Any, checkpoint_path: Path) -> Path | None:
     return path
 
 
-def _load_checkpoint(vla: Any, checkpoint_path: Path) -> None:
-    if checkpoint_path.suffix == '.safetensors':
+def _load_checkpoint(vla: Any,
+                     checkpoint_path: Path,
+                     name_mapping: Mapping[str, str] | None = None) -> None:
+    if checkpoint_path.is_dir():
         from safetensors.torch import load_file
-        checkpoint = load_file(str(checkpoint_path), device='cpu')
+        shards = sorted(checkpoint_path.glob('model-*.safetensors'))
+        if not shards:
+            raise FileNotFoundError(
+                f'No model-*.safetensors files found in {checkpoint_path}')
+        state_dict = {}
+        for shard in shards:
+            state_dict.update(load_file(str(shard), device='cpu'))
+    elif checkpoint_path.suffix == '.safetensors':
+        from safetensors.torch import load_file
+        state_dict = load_file(str(checkpoint_path), device='cpu')
     else:
         checkpoint = torch.load(checkpoint_path, map_location='cpu')
-    state_dict = (
-        checkpoint['model'] if isinstance(checkpoint, Mapping)
-        and 'model' in checkpoint else checkpoint)
+        state_dict = (
+            checkpoint['model'] if isinstance(checkpoint, Mapping)
+            and 'model' in checkpoint else checkpoint)
+
+    if name_mapping:
+        if not isinstance(name_mapping, Mapping):
+            raise TypeError('model.name_mapping must be a mapping')
+
+        def has_prefix(key: str, prefix: str) -> bool:
+            return key == prefix or key.startswith(f'{prefix}.')
+
+        native_prefixes = tuple(name_mapping)
+        source_prefixes = tuple(name_mapping.values())
+        has_native_keys = any(
+            any(has_prefix(key, prefix) for key in state_dict)
+            for prefix in native_prefixes)
+        needs_mapping = (
+            any(
+                any(has_prefix(key, prefix) for key in state_dict)
+                for prefix in source_prefixes) and not has_native_keys)
+        if needs_mapping:
+            mapped_state_dict = {}
+            for native_prefix, source_prefix in name_mapping.items():
+                if not isinstance(native_prefix, str) or not isinstance(
+                        source_prefix, str):
+                    raise TypeError(
+                        'model.name_mapping keys and values must be strings')
+                for key, value in state_dict.items():
+                    if has_prefix(key, source_prefix):
+                        mapped_key = native_prefix + key[len(source_prefix):]
+                        mapped_state_dict[mapped_key] = value
+            state_dict = mapped_state_dict
+
+    from fluxvla.engines.utils.checkpoint_utils import handle_shared_tensors
+    state_dict = handle_shared_tensors(state_dict, vla.state_dict())
     vla.load_state_dict(state_dict, strict=True)
 
 
@@ -1193,6 +1255,24 @@ def _prepare_denormalize_context(context: dict[str,
     transform_name = (
         transform_type if isinstance(transform_type, str) else getattr(
             transform_type, '__name__', str(transform_type)))
+    if 'Robocasa' in transform_name:
+        section_key = section_cfg.get('unnorm_key')
+        transport_key = transport.get('unnorm_key')
+        if section_key and transport_key and section_key != transport_key:
+            raise ValueError('RoboCasa section.unnorm_key and '
+                             'themis.transport.unnorm_key must match')
+        stats_key = transport_key or section_key
+        if not stats_key:
+            raise KeyError(
+                'RoboCasa ROS serving requires an unnorm_key in the eval '
+                'section or themis.transport')
+        configured_key = context.get('task_suite_name')
+        if configured_key and configured_key != stats_key:
+            raise ValueError(
+                'RoboCasa denormalize_context.task_suite_name must match '
+                'the configured unnorm_key')
+        context['task_suite_name'] = stats_key
+        return
     task_suite_name = section_cfg.get('task_suite_name')
     if task_suite_name:
         context.setdefault('task_suite_name', task_suite_name)
@@ -1202,6 +1282,27 @@ def _prepare_denormalize_context(context: dict[str,
             section_cfg.get('norm_stats_key')
             or (f'{task_suite_name}_no_noops'
                 if task_suite_name else transport.get('unnorm_key', '')))
+
+
+def _validate_denormalization_stats(transform: Any,
+                                    context: Mapping[str, Any]) -> None:
+    norm_stats = getattr(transform, 'norm_stats', None)
+    transform_name = type(transform).__name__
+    if 'Libero' in transform_name:
+        stats_key = context.get('norm_stats_key')
+    else:
+        stats_key = (
+            context.get('task_suite_name') or context.get('norm_stats_key'))
+    if not isinstance(norm_stats, Mapping) or not stats_key:
+        return
+    if stats_key not in norm_stats:
+        raise KeyError(
+            f'Normalization statistics key {stats_key!r} is missing; '
+            f'available keys: {list(norm_stats)}')
+    stats = norm_stats[stats_key]
+    if not isinstance(stats, Mapping) or 'action' not in stats:
+        raise KeyError(
+            f'Normalization statistics {stats_key!r} must contain action')
 
 
 def _config_get(config: Any, key: str, default: Any = None) -> Any:

--- a/fluxvla/engines/runners/serving/ros_server.py
+++ b/fluxvla/engines/runners/serving/ros_server.py
@@ -1,0 +1,745 @@
+# Copyright 2026 Limx Dynamics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""ROS inference service used by FluxThemis.
+
+ROS imports are intentionally delayed until :meth:`FluxVLAROSServer.run` so
+normal FluxVLA training and evaluation do not require a sourced ROS workspace.
+"""
+from __future__ import annotations
+import copy
+import importlib
+import json
+import os
+import random
+import threading
+import time
+from collections.abc import Mapping, Sequence
+from contextlib import contextmanager, nullcontext
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+
+_MISSING = object()
+
+
+class _RawImageBridge:
+    """Decode the ROS ``sensor_msgs/Image`` subset used by FluxThemis.
+
+    ROS 1 Noetic's binary ``cv_bridge`` is tied to the Python ABI it was
+    compiled against.  FluxThemis only sends packed 8-bit RGB/BGR images, so
+    decoding that small, well-defined subset directly keeps a Python 3.10
+    source-built ROS 1 workspace independent of ``cv_bridge``.
+    """
+
+    _SUPPORTED_ENCODINGS = frozenset({'rgb8', 'bgr8'})
+
+    def __init__(self, image_type: type | None = None) -> None:
+        self._image_type = image_type
+
+    def imgmsg_to_cv2(self, message: Any, desired_encoding: str) -> np.ndarray:
+        if self._image_type is not None and not isinstance(
+                message, self._image_type):
+            raise TypeError(
+                'ROS image must be a sensor_msgs/Image instance, got '
+                f'{type(message).__name__}')
+        if desired_encoding not in self._SUPPORTED_ENCODINGS:
+            raise ValueError(
+                f'Unsupported desired image encoding {desired_encoding!r}; '
+                'expected rgb8 or bgr8')
+
+        encoding = getattr(message, 'encoding', None)
+        if encoding not in self._SUPPORTED_ENCODINGS:
+            raise ValueError(
+                f'Unsupported ROS image encoding {encoding!r}; expected '
+                'rgb8 or bgr8')
+        if encoding != desired_encoding:
+            raise ValueError(
+                f'ROS image encoding {encoding!r} does not match requested '
+                f'encoding {desired_encoding!r}')
+
+        height = self._positive_integer_field(message, 'height')
+        width = self._positive_integer_field(message, 'width')
+        step = self._positive_integer_field(message, 'step')
+        packed_step = width * 3
+        if step < packed_step:
+            raise ValueError(
+                f'ROS image step {step} is smaller than the packed row size '
+                f'{packed_step}')
+
+        try:
+            payload = bytes(getattr(message, 'data'))
+        except (AttributeError, TypeError, ValueError) as exc:
+            raise TypeError('ROS image data must be a byte sequence') from exc
+        expected_size = height * step
+        if len(payload) != expected_size:
+            raise ValueError(
+                f'ROS image data has {len(payload)} bytes; expected exactly '
+                f'{expected_size} for height={height} and step={step}')
+
+        rows = np.frombuffer(payload, dtype=np.uint8).reshape(height, step)
+        return rows[:, :packed_step].reshape(height, width, 3).copy()
+
+    @staticmethod
+    def _positive_integer_field(message: Any, name: str) -> int:
+        value = getattr(message, name, None)
+        if isinstance(value, bool) or not isinstance(value, (int, np.integer)):
+            raise TypeError(f'ROS image {name} must be an integer')
+        value = int(value)
+        if value <= 0:
+            raise ValueError(f'ROS image {name} must be positive')
+        return value
+
+
+class FluxVLAROSPolicy:
+    """Model, preprocessing and action-unit boundary for the ROS server."""
+
+    def __init__(self,
+                 vla: Any,
+                 dataset: Any,
+                 denormalize_action: Any = None,
+                 device: str = 'cuda:0',
+                 mixed_precision_dtype: torch.dtype = torch.bfloat16,
+                 enable_mixed_precision: bool = True,
+                 model_outputs_environment_actions: bool = False,
+                 forward_seed: bool = False,
+                 denormalize_context: Mapping[str, Any] | None = None,
+                 denormalize_per_action: bool = False) -> None:
+        if not callable(dataset):
+            raise TypeError('FluxVLA ROS server dataset must be callable')
+        if (not model_outputs_environment_actions
+                and not callable(denormalize_action)):
+            raise RuntimeError(
+                'A denormalize_action transform is required unless '
+                'model_outputs_environment_actions=True is explicitly set.')
+        if not isinstance(mixed_precision_dtype, torch.dtype):
+            raise TypeError('mixed_precision_dtype must be a torch dtype')
+        if mixed_precision_dtype not in {
+                torch.float32, torch.float16, torch.bfloat16
+        }:
+            raise ValueError(
+                'mixed_precision_dtype must be fp32, fp16, or bf16')
+        if not isinstance(enable_mixed_precision, bool):
+            raise TypeError('enable_mixed_precision must be a bool')
+        if not isinstance(model_outputs_environment_actions, bool):
+            raise TypeError('model_outputs_environment_actions must be a bool')
+        if not isinstance(forward_seed, bool):
+            raise TypeError('forward_seed must be a bool')
+        if not isinstance(denormalize_per_action, bool):
+            raise TypeError('denormalize_per_action must be a bool')
+        if denormalize_context is not None and not isinstance(
+                denormalize_context, Mapping):
+            raise TypeError('denormalize_context must be a mapping')
+
+        self.vla = vla
+        self.dataset = dataset
+        self.denormalize_action = denormalize_action
+        self.device = torch.device(device)
+        self.mixed_precision_dtype = mixed_precision_dtype
+        self.enable_mixed_precision = enable_mixed_precision
+        self.model_outputs_environment_actions = \
+            model_outputs_environment_actions
+        self.forward_seed = forward_seed
+        self.denormalize_context = dict(denormalize_context or {})
+        self.denormalize_per_action = denormalize_per_action
+        self._lock = threading.RLock()
+
+        if self.device.type == 'cuda':
+            torch.cuda.set_device(self.device)
+        self.vla.eval()
+        self.vla.to(self.device)
+
+    def predict(self, observation: Mapping[str, Any], unnorm_key: str,
+                seed: int) -> tuple[np.ndarray, float]:
+        """Preprocess one request and return environment-unit ``[T, A]``."""
+        if not isinstance(observation, Mapping):
+            raise TypeError('observation must be a mapping')
+        with self._lock, self._seed_context(seed):
+            result = self.dataset(dict(observation))
+            batch = result[0] if isinstance(result, tuple) else result
+            if not isinstance(batch, Mapping):
+                raise TypeError(
+                    'FluxVLA dataset pipeline must return a mapping or a '
+                    'tuple whose first item is a mapping')
+            batch = dict(batch)
+            batch.setdefault('reset_history',
+                             bool(observation.get('is_new_episode')))
+            if unnorm_key:
+                batch['unnorm_key'] = unnorm_key
+            if self.forward_seed:
+                batch['seed'] = int(seed)
+            batch = self._move_to_device(batch)
+
+            if self.device.type == 'cuda':
+                torch.cuda.synchronize(self.device)
+            started = time.perf_counter()
+            with torch.no_grad(), self._autocast_context():
+                raw_actions = self.vla.predict_action(**batch)
+            if self.device.type == 'cuda':
+                torch.cuda.synchronize(self.device)
+            inference_time_s = time.perf_counter() - started
+            actions = self._to_environment_actions(
+                raw_actions, unnorm_key=unnorm_key)
+        return actions, inference_time_s
+
+    @contextmanager
+    def _seed_context(self, seed: int):
+        if not self.forward_seed:
+            yield
+            return
+
+        python_state = random.getstate()
+        numpy_state = np.random.get_state()
+        cuda_devices = []
+        if self.device.type == 'cuda':
+            device_index = self.device.index
+            if device_index is None:
+                device_index = torch.cuda.current_device()
+            cuda_devices.append(device_index)
+        try:
+            with torch.random.fork_rng(devices=cuda_devices):
+                random.seed(int(seed))
+                np.random.seed(int(seed) % (2**32))
+                torch.random.default_generator.manual_seed(int(seed))
+                if self.device.type == 'cuda':
+                    torch.cuda.manual_seed(int(seed))
+                yield
+        finally:
+            random.setstate(python_state)
+            np.random.set_state(numpy_state)
+
+    def _autocast_context(self):
+        enabled = (
+            self.enable_mixed_precision and self.device.type == 'cuda'
+            and self.mixed_precision_dtype in {torch.bfloat16, torch.float16})
+        if not enabled:
+            return nullcontext()
+        return torch.autocast(
+            device_type='cuda', dtype=self.mixed_precision_dtype)
+
+    def _to_environment_actions(self,
+                                raw_actions: Any,
+                                unnorm_key: str = '') -> np.ndarray:
+        raw_array = self._as_numpy(raw_actions)
+        if self.model_outputs_environment_actions:
+            return self._canonicalize_actions(raw_array)
+
+        context = dict(self.denormalize_context)
+        if unnorm_key:
+            context.setdefault('unnorm_key', unnorm_key)
+            context.setdefault('norm_stats_key', unnorm_key)
+            context.setdefault('task_suite_name', unnorm_key)
+
+        if self.denormalize_per_action:
+            normalized = self._canonicalize_actions(raw_array)
+            denormalized = []
+            for action in normalized:
+                value = self._call_denormalizer(action, context)
+                value = np.asarray(value)
+                if value.ndim == 2 and value.shape[0] == 1:
+                    value = value[0]
+                if value.ndim != 1:
+                    raise ValueError(
+                        'Per-action denormalizer must return shape [A], got '
+                        f'{value.shape}')
+                denormalized.append(value)
+            return self._canonicalize_actions(np.stack(denormalized))
+
+        value = self._call_denormalizer(raw_array, context)
+        return self._canonicalize_actions(value)
+
+    def _call_denormalizer(self, actions: np.ndarray,
+                           context: Mapping[str, Any]) -> np.ndarray:
+        payload = dict(context)
+        payload['action'] = actions
+        value = self.denormalize_action(payload)
+        if isinstance(value, Mapping):
+            if 'action' not in value:
+                raise KeyError(
+                    'denormalize_action returned a mapping without `action`')
+            value = value['action']
+        return self._as_numpy(value)
+
+    def _move_to_device(self, value: Any) -> Any:
+        if isinstance(value, torch.Tensor):
+            return value.to(self.device)
+        if isinstance(value, Mapping):
+            return {
+                key: self._move_to_device(item)
+                for key, item in value.items()
+            }
+        if isinstance(value, tuple):
+            return tuple(self._move_to_device(item) for item in value)
+        if isinstance(value, list):
+            return [self._move_to_device(item) for item in value]
+        return value
+
+    @staticmethod
+    def _as_numpy(value: Any) -> np.ndarray:
+        if isinstance(value, torch.Tensor):
+            value = value.detach().float().cpu().numpy()
+        return np.asarray(value)
+
+    @staticmethod
+    def _canonicalize_actions(value: Any) -> np.ndarray:
+        actions = np.asarray(value)
+        if actions.ndim == 3:
+            if actions.shape[0] != 1:
+                raise ValueError(
+                    'FluxVLA ROS inference only supports batch size 1, got '
+                    f'{actions.shape}')
+            actions = actions[0]
+        elif actions.ndim == 1:
+            actions = actions[None, :]
+        elif actions.ndim != 2:
+            raise ValueError('FluxVLA actions must have shape [A], [T, A], or '
+                             f'[1, T, A], got {actions.shape}')
+        try:
+            actions = np.asarray(actions, dtype=np.float32)
+        except (TypeError, ValueError) as exc:
+            raise ValueError('FluxVLA actions must be numeric') from exc
+        if actions.shape[0] == 0 or actions.shape[1] == 0:
+            raise ValueError('FluxVLA returned an empty action chunk')
+        if not np.isfinite(actions).all():
+            raise ValueError('FluxVLA returned NaN or infinite actions')
+        return actions
+
+
+class FluxVLAROSServer:
+    """Lazy-ROS wrapper exposing :class:`FluxVLAROSPolicy` as a service."""
+
+    def __init__(self,
+                 policy: FluxVLAROSPolicy,
+                 transport: Mapping[str, Any],
+                 node_name: str = 'fluxvla_inference_server') -> None:
+        if not isinstance(transport, Mapping):
+            raise TypeError('themis.transport must be a mapping')
+        self.policy = policy
+        self.service_name = self._nonempty_string(
+            transport.get('service_name', '/fluxvla/predict_action'),
+            'themis.transport.service_name')
+        self.image_keys = self._keys(
+            transport.get('image_keys'), 'themis.transport.image_keys')
+        self.state_keys = self._keys(
+            transport.get('state_keys'), 'themis.transport.state_keys')
+        self.image_encoding = self._nonempty_string(
+            transport.get('image_encoding', 'rgb8'),
+            'themis.transport.image_encoding')
+        self.node_name = self._nonempty_string(node_name, 'node_name')
+
+        self._rospy = None
+        self._bridge = None
+        self._response_type = None
+        self._service = None
+        self._request_lock = threading.RLock()
+        self._last_episode_id: str | None = None
+        self._last_seed: int | None = None
+
+    def run(self) -> None:
+        """Import ROS, advertise the service and block in ``rospy.spin``."""
+        try:
+            rospy = importlib.import_module('rospy')
+            sensor_msgs = importlib.import_module('sensor_msgs.msg')
+            service_module = importlib.import_module('fluxthemis_msgs.srv')
+            bridge = _RawImageBridge(getattr(sensor_msgs, 'Image'))
+            service_type = getattr(service_module, 'PredictAction')
+            response_type = getattr(service_module, 'PredictActionResponse')
+        except (ImportError, AttributeError) as exc:
+            raise ImportError(
+                'FluxVLA ROS serving requires ROS1 rospy, sensor_msgs/Image '
+                'and the generated fluxthemis_msgs/PredictAction service. '
+                'Source the ROS 1 workspace before launching the server.') \
+                from exc
+
+        rospy.init_node(self.node_name, anonymous=False)
+        self._bind_ros(rospy, bridge, response_type)
+        self._service = rospy.Service(self.service_name, service_type,
+                                      self.handle_request)
+        rospy.loginfo(f'FluxVLA ROS inference ready on {self.service_name}')
+        rospy.spin()
+
+    def _bind_ros(self, rospy: Any, bridge: Any, response_type: Any) -> None:
+        """Bind generated ROS types for dependency-free tests."""
+        self._rospy = rospy
+        self._bridge = bridge
+        self._response_type = response_type
+
+    def handle_request(self, request: Any, response: Any = None) -> Any:
+        if (self._rospy is None or self._bridge is None
+                or self._response_type is None):
+            raise RuntimeError('FluxVLAROSServer.run() was not called')
+        if response is None:
+            response = self._response_type()
+        request_id = str(getattr(request, 'request_id', ''))
+        response.request_id = request_id
+        response.header.stamp = self._rospy.Time.now()
+        try:
+            with self._request_lock:
+                observation, episode_id, seed, unnorm_key = \
+                    self._decode_request(request)
+                is_new_episode = (
+                    bool(request.reset) or episode_id != self._last_episode_id
+                    or seed != self._last_seed)
+                observation['is_new_episode'] = is_new_episode
+                actions, inference_time_s = self.policy.predict(
+                    observation, unnorm_key=unnorm_key, seed=seed)
+                self._last_episode_id = episode_id
+                self._last_seed = seed
+
+            response.ok = True
+            response.error = ''
+            response.actions = actions.reshape(-1).tolist()
+            response.action_horizon = int(actions.shape[0])
+            response.action_dim = int(actions.shape[1])
+            response.denormalized = True
+            response.inference_time_s = float(inference_time_s)
+        except Exception as exc:  # ROS callbacks must return a response.
+            response.ok = False
+            response.error = f'{type(exc).__name__}: {exc}'
+            response.actions = []
+            response.action_horizon = 0
+            response.action_dim = 0
+            response.denormalized = False
+            response.inference_time_s = 0.0
+            logerr = getattr(self._rospy, 'logerr', None)
+            if callable(logerr):
+                logerr(f'FluxVLA ROS request {request_id or "<missing>"} '
+                       f'failed: {response.error}')
+        return response
+
+    def _decode_request(self,
+                        request: Any) -> tuple[dict[str, Any], str, int, str]:
+        request_id = self._nonempty_string(
+            getattr(request, 'request_id', ''), 'request.request_id')
+        del request_id
+        episode_id = self._nonempty_string(
+            getattr(request, 'episode_id', ''), 'request.episode_id')
+        prompt = self._nonempty_string(
+            getattr(request, 'prompt', ''), 'request.prompt')
+
+        image_names = list(getattr(request, 'image_names', []))
+        image_messages = list(getattr(request, 'images', []))
+        if tuple(image_names) != self.image_keys:
+            raise ValueError(f'Expected image_names {self.image_keys}, got '
+                             f'{tuple(image_names)}')
+        if len(image_messages) != len(image_names):
+            raise ValueError(
+                'request.images and request.image_names must have the same '
+                'length')
+
+        observation: dict[str, Any] = {}
+        for name, message in zip(image_names, image_messages):
+            image = self._bridge.imgmsg_to_cv2(
+                message, desired_encoding=self.image_encoding)
+            observation[name] = self._validate_image(image, name)
+
+        state_names = list(getattr(request, 'state_names', []))
+        state_sizes = list(getattr(request, 'state_sizes', []))
+        state_values = np.asarray(
+            getattr(request, 'state_values', []), dtype=np.float32)
+        if tuple(state_names) != self.state_keys:
+            raise ValueError(f'Expected state_names {self.state_keys}, got '
+                             f'{tuple(state_names)}')
+        if len(state_sizes) != len(state_names):
+            raise ValueError(
+                'request.state_sizes and request.state_names must have the '
+                'same length')
+        if state_values.ndim != 1:
+            raise ValueError('request.state_values must be flat')
+        if not np.isfinite(state_values).all():
+            raise ValueError('request.state_values contains NaN or infinity')
+        offset = 0
+        for name, size_value in zip(state_names, state_sizes):
+            size = int(size_value)
+            if size <= 0:
+                raise ValueError('Every request.state_sizes entry must be '
+                                 'positive')
+            end = offset + size
+            if end > state_values.size:
+                raise ValueError(
+                    'request.state_values is shorter than state_sizes')
+            observation[name] = state_values[offset:end].copy()
+            offset = end
+        if offset != state_values.size:
+            raise ValueError(
+                'request.state_values length does not equal sum(state_sizes)')
+        observation['task_description'] = prompt
+
+        seed = int(getattr(request, 'seed'))
+        unnorm_key = getattr(request, 'unnorm_key', '')
+        if not isinstance(unnorm_key, str):
+            raise TypeError('request.unnorm_key must be a string')
+        return observation, episode_id, seed, unnorm_key
+
+    @staticmethod
+    def _validate_image(value: Any, name: str) -> np.ndarray:
+        image = np.asarray(value)
+        if image.dtype != np.uint8:
+            raise TypeError(
+                f'Image {name!r} must have dtype uint8, got {image.dtype}')
+        if image.ndim != 3 or image.shape[2] != 3:
+            raise ValueError(f'Image {name!r} must have shape [H, W, 3], got '
+                             f'{image.shape}')
+        if image.shape[0] == 0 or image.shape[1] == 0:
+            raise ValueError(f'Image {name!r} cannot be empty')
+        return np.ascontiguousarray(image)
+
+    @classmethod
+    def _keys(cls, value: Any, name: str) -> tuple[str, ...]:
+        if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+            raise TypeError(f'{name} must be a sequence')
+        keys = tuple(value)
+        if not keys:
+            raise ValueError(f'{name} cannot be empty')
+        for key in keys:
+            cls._nonempty_string(key, f'{name} entry')
+        if len(keys) != len(set(keys)):
+            raise ValueError(f'{name} cannot contain duplicates')
+        return keys
+
+    @staticmethod
+    def _nonempty_string(value: Any, name: str) -> str:
+        if not isinstance(value, str):
+            raise TypeError(f'{name} must be a string')
+        if not value:
+            raise ValueError(f'{name} cannot be empty')
+        return value
+
+
+def build_ros_server_from_config(
+        cfg: Any,
+        ckpt_path: str | None = None,
+        device: str | None = None,
+        service_name: str | None = None,
+        node_name: str | None = None,
+        ros_version: int | str | None = None) -> FluxVLAROSServer:
+    """Build a ROS 1 or ROS 2 server from one FluxVLA configuration.
+
+    ``ros_version`` overrides ``themis.ros_server.ros_version``.  ROS 1 stays
+    the default so existing launch commands and configurations are unchanged.
+    """
+    themis_cfg = _require_mapping(
+        _config_get(cfg, 'themis', _MISSING), 'config.themis')
+    transport = dict(
+        _require_mapping(
+            themis_cfg.get('transport', _MISSING), 'themis.transport'))
+    server_cfg = dict(
+        _require_mapping(
+            themis_cfg.get('ros_server', _MISSING), 'themis.ros_server'))
+    configured_ros_version = server_cfg.get('ros_version', 1)
+    requested_ros_version = (
+        configured_ros_version if ros_version is None else ros_version)
+    resolved_ros_version = _resolve_ros_version(requested_ros_version)
+    if service_name is not None:
+        transport['service_name'] = service_name
+
+    section_name = server_cfg.get('dataset_section')
+    if section_name not in {'eval', 'inference'}:
+        raise ValueError('themis.ros_server.dataset_section must be `eval` or '
+                         '`inference`')
+    section_cfg = _require_mapping(
+        _config_get(cfg, section_name, _MISSING), f'config.{section_name}')
+    dataset_cfg = copy.deepcopy(
+        _require_mapping(
+            section_cfg.get('dataset', _MISSING),
+            f'config.{section_name}.dataset'))
+
+    resolved_ckpt = _resolve_checkpoint_path(
+        ckpt_path or server_cfg.get('ckpt_path')
+        or section_cfg.get('ckpt_path'))
+    stats_path = _resolve_statistics_path(
+        server_cfg.get('norm_stats_path'), resolved_ckpt)
+    model_outputs_environment_actions = server_cfg.get(
+        'model_outputs_environment_actions', False)
+    if not model_outputs_environment_actions and stats_path is None:
+        raise FileNotFoundError(
+            'dataset_statistics.json is required to prove the ROS action '
+            'unit contract')
+
+    from fluxvla.engines import (build_dataset_from_cfg,
+                                 build_transform_from_cfg, build_vla_from_cfg)
+    from fluxvla.engines.utils import str_to_dtype
+
+    model_cfg = _config_get(cfg, 'inference_model', None)
+    if model_cfg is None:
+        model_cfg = _config_get(cfg, 'model', _MISSING)
+    if model_cfg is _MISSING:
+        raise KeyError('FluxVLA config must define `model` or '
+                       '`inference_model`')
+    vla = build_vla_from_cfg(model_cfg)
+    _load_checkpoint(vla, resolved_ckpt)
+    if stats_path is not None:
+        with stats_path.open('r', encoding='utf-8') as stream:
+            vla.norm_stats = json.load(stream)
+
+    _prepare_dataset_config(
+        dataset_cfg=dataset_cfg,
+        section_cfg=section_cfg,
+        transport=transport,
+        stats_path=stats_path,
+        model_root=resolved_ckpt.parent.parent,
+    )
+    dataset = build_dataset_from_cfg(dataset_cfg)
+
+    denormalize_action = None
+    denormalize_context = dict(
+        _require_mapping(
+            server_cfg.get('denormalize_context', {}),
+            'themis.ros_server.denormalize_context'))
+    if not model_outputs_environment_actions:
+        denorm_cfg = copy.deepcopy(
+            _require_mapping(
+                section_cfg.get('denormalize_action', _MISSING),
+                f'config.{section_name}.denormalize_action'))
+        denorm_cfg['norm_stats'] = str(stats_path)
+        denormalize_action = build_transform_from_cfg(denorm_cfg)
+        _prepare_denormalize_context(denormalize_context, denorm_cfg,
+                                     section_cfg, transport)
+
+    resolved_device = device or server_cfg.get('device', 'cuda:0')
+    dtype_name = server_cfg.get('mixed_precision_dtype', 'bf16')
+    policy = FluxVLAROSPolicy(
+        vla=vla,
+        dataset=dataset,
+        denormalize_action=denormalize_action,
+        device=resolved_device,
+        mixed_precision_dtype=str_to_dtype(str(dtype_name)),
+        enable_mixed_precision=server_cfg.get('enable_mixed_precision', True),
+        model_outputs_environment_actions=model_outputs_environment_actions,
+        forward_seed=server_cfg.get('forward_seed', False),
+        denormalize_context=denormalize_context,
+        denormalize_per_action=server_cfg.get('denormalize_per_action', False),
+    )
+    server_type = FluxVLAROSServer
+    if resolved_ros_version == 2:
+        from .ros2_server import FluxVLAROS2Server
+        server_type = FluxVLAROS2Server
+    return server_type(
+        policy=policy,
+        transport=transport,
+        node_name=node_name
+        or server_cfg.get('node_name', 'fluxvla_inference_server'),
+    )
+
+
+def _resolve_ros_version(value: Any) -> int:
+    if isinstance(value, bool):
+        raise TypeError('ROS version must be 1 or 2, not a bool')
+    if isinstance(value, str):
+        value = value.strip()
+    elif not isinstance(value, int):
+        raise TypeError('ROS version must be an integer or string')
+    if value == 1 or value == '1':
+        return 1
+    if value == 2 or value == '2':
+        return 2
+    raise ValueError('ROS version must be 1 or 2')
+
+
+def _resolve_checkpoint_path(value: Any) -> Path:
+    if not isinstance(value, (str, os.PathLike)) or not str(value):
+        raise ValueError(
+            'Checkpoint path is required via --ckpt-path, '
+            'themis.ros_server.ckpt_path, or the selected section.ckpt_path')
+    path = Path(value).expanduser().resolve()
+    if not path.is_file():
+        raise FileNotFoundError(f'Checkpoint not found: {path}')
+    return path
+
+
+def _resolve_statistics_path(value: Any, checkpoint_path: Path) -> Path | None:
+    explicit = value is not None
+    path = (
+        Path(value).expanduser().resolve() if explicit else
+        checkpoint_path.parent.parent / 'dataset_statistics.json')
+    if not path.is_file():
+        if explicit:
+            raise FileNotFoundError(
+                f'Configured norm_stats_path not found: {path}')
+        return None
+    return path
+
+
+def _load_checkpoint(vla: Any, checkpoint_path: Path) -> None:
+    if checkpoint_path.suffix == '.safetensors':
+        from safetensors.torch import load_file
+        checkpoint = load_file(str(checkpoint_path), device='cpu')
+    else:
+        checkpoint = torch.load(checkpoint_path, map_location='cpu')
+    state_dict = (
+        checkpoint['model'] if isinstance(checkpoint, Mapping)
+        and 'model' in checkpoint else checkpoint)
+    vla.load_state_dict(state_dict, strict=True)
+
+
+def _prepare_dataset_config(dataset_cfg: dict, section_cfg: Mapping[str, Any],
+                            transport: Mapping[str, Any],
+                            stats_path: Path | None, model_root: Path) -> None:
+    if stats_path is not None:
+        dataset_cfg['norm_stats'] = str(stats_path)
+    dataset_type = dataset_cfg.get('type', '')
+    dataset_type_name = (
+        dataset_type if isinstance(dataset_type, str) else getattr(
+            dataset_type, '__name__', str(dataset_type)))
+    task_suite_name = section_cfg.get('task_suite_name')
+
+    if 'Libero' in dataset_type_name:
+        if not task_suite_name:
+            raise KeyError(
+                'Libero ROS serving requires section.task_suite_name')
+        dataset_cfg.setdefault('task_suite_name', task_suite_name)
+        dataset_cfg.setdefault(
+            'norm_stats_key',
+            section_cfg.get('norm_stats_key') or f'{task_suite_name}_no_noops')
+    if 'PrivateInferenceDataset' in dataset_type_name:
+        dataset_cfg.setdefault('model_path', str(model_root))
+    if 'Robocasa' in dataset_type_name:
+        unnorm_key = transport.get('unnorm_key')
+        if unnorm_key:
+            dataset_cfg.setdefault('unnorm_key', unnorm_key)
+
+
+def _prepare_denormalize_context(context: dict[str,
+                                               Any], denorm_cfg: Mapping[str,
+                                                                         Any],
+                                 section_cfg: Mapping[str, Any],
+                                 transport: Mapping[str, Any]) -> None:
+    transform_type = denorm_cfg.get('type', '')
+    transform_name = (
+        transform_type if isinstance(transform_type, str) else getattr(
+            transform_type, '__name__', str(transform_type)))
+    task_suite_name = section_cfg.get('task_suite_name')
+    if task_suite_name:
+        context.setdefault('task_suite_name', task_suite_name)
+    if 'Libero' in transform_name:
+        context.setdefault(
+            'norm_stats_key',
+            section_cfg.get('norm_stats_key')
+            or (f'{task_suite_name}_no_noops'
+                if task_suite_name else transport.get('unnorm_key', '')))
+
+
+def _config_get(config: Any, key: str, default: Any = None) -> Any:
+    if isinstance(config, Mapping):
+        return config.get(key, default)
+    return getattr(config, key, default)
+
+
+def _require_mapping(value: Any, name: str) -> Mapping[str, Any]:
+    if value is _MISSING:
+        raise KeyError(f'{name} is required')
+    if not isinstance(value, Mapping):
+        raise TypeError(f'{name} must be a mapping')
+    return value

--- a/fluxvla/engines/runners/serving/ros_worker_pool.py
+++ b/fluxvla/engines/runners/serving/ros_worker_pool.py
@@ -1,0 +1,488 @@
+# Copyright 2026 Limx Dynamics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Episode-affine process workers for multi-GPU ROS inference.
+
+Each worker owns one complete FluxVLA policy on one device.  Requests from an
+episode stay on that worker until FluxThemis acknowledges ``episode_end``.
+This is deliberately replica-based serving, not tensor/model parallelism:
+stateful dataset and model histories must never be interleaved across active
+episodes.
+"""
+from __future__ import annotations
+import multiprocessing as mp
+import threading
+import time
+import traceback
+from dataclasses import dataclass
+from multiprocessing.connection import Connection
+from typing import Any, Sequence
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class _EpisodeLease:
+    worker_index: int
+    seed: int
+
+
+class EpisodeAffinityPolicyPool:
+    """Dispatch complete episodes across independent policy backends."""
+
+    supports_episode_affinity = True
+
+    def __init__(self,
+                 backends: Sequence[Any],
+                 lease_timeout_s: float = 900.0) -> None:
+        if isinstance(backends,
+                      (str, bytes)) or not isinstance(backends, Sequence):
+            raise TypeError('backends must be a sequence')
+        if not backends:
+            raise ValueError('backends cannot be empty')
+        if isinstance(lease_timeout_s,
+                      bool) or not isinstance(lease_timeout_s, (int, float)):
+            raise TypeError('lease_timeout_s must be a number')
+        if lease_timeout_s <= 0:
+            raise ValueError('lease_timeout_s must be positive')
+        for backend in backends:
+            if not callable(getattr(backend, 'predict', None)):
+                raise TypeError('every backend must define predict()')
+
+        self._backends = tuple(backends)
+        self.lease_timeout_s = float(lease_timeout_s)
+        self.worker_devices = tuple(
+            str(getattr(backend, 'device', index))
+            for index, backend in enumerate(self._backends))
+        self._condition = threading.Condition(threading.RLock())
+        self._leases: dict[str, _EpisodeLease] = {}
+        self._worker_episodes: list[str
+                                    | None] = [None for _ in self._backends]
+        self._next_worker = 0
+        self._closed = False
+        self._fatal_error: RuntimeError | None = None
+
+    @property
+    def worker_count(self) -> int:
+        return len(self._backends)
+
+    @property
+    def active_episode_ids(self) -> tuple[str, ...]:
+        with self._condition:
+            return tuple(self._leases)
+
+    def predict(self,
+                observation: Any,
+                unnorm_key: str,
+                seed: int,
+                *,
+                episode_id: str,
+                reset: bool = False) -> tuple[np.ndarray, float]:
+        """Lease a backend and run one prediction without changing affinity."""
+        if not isinstance(episode_id, str) or not episode_id:
+            raise ValueError('episode_id must be a non-empty string')
+        if isinstance(seed, bool) or not isinstance(seed, int):
+            raise TypeError('seed must be an integer')
+        if not isinstance(reset, bool):
+            raise TypeError('reset must be a bool')
+
+        lease, first_request = self._acquire_lease(episode_id, seed)
+        worker_observation = dict(observation)
+        worker_observation['is_new_episode'] = bool(first_request or reset)
+        backend = self._backends[lease.worker_index]
+        try:
+            return backend.predict(
+                worker_observation,
+                unnorm_key=unnorm_key,
+                seed=seed,
+            )
+        except Exception as exc:
+            worker_device = self.worker_devices[lease.worker_index]
+            failure = RuntimeError(
+                'FluxVLA inference worker '
+                f'{lease.worker_index} ({worker_device}) '
+                f'failed during episode {episode_id!r}: {exc}')
+            with self._condition:
+                self._fatal_error = failure
+                self._condition.notify_all()
+            raise failure from exc
+
+    def release_episode(self, episode_id: str) -> bool:
+        """Release one episode after its durable ``episode_end`` report."""
+        if not isinstance(episode_id, str) or not episode_id:
+            raise ValueError('episode_id must be a non-empty string')
+        with self._condition:
+            lease = self._leases.pop(episode_id, None)
+            if lease is None:
+                return False
+            if self._worker_episodes[lease.worker_index] == episode_id:
+                self._worker_episodes[lease.worker_index] = None
+            self._condition.notify_all()
+            return True
+
+    def release_all(self) -> None:
+        """Clear every affinity lease after a terminal run event."""
+        with self._condition:
+            self._leases.clear()
+            self._worker_episodes = [None for _ in self._backends]
+            self._condition.notify_all()
+
+    def close(self) -> None:
+        """Stop all backends.  Safe to call repeatedly."""
+        with self._condition:
+            if self._closed:
+                return
+            self._closed = True
+            self._condition.notify_all()
+        errors = []
+        for backend in self._backends:
+            close = getattr(backend, 'close', None)
+            if callable(close):
+                try:
+                    close()
+                except Exception as exc:  # pragma: no cover - cleanup guard
+                    errors.append(exc)
+        if errors:
+            raise RuntimeError(
+                'Failed to close one or more FluxVLA inference workers: ' +
+                '; '.join(str(error) for error in errors))
+
+    def _acquire_lease(self, episode_id: str,
+                       seed: int) -> tuple[_EpisodeLease, bool]:
+        deadline = time.monotonic() + self.lease_timeout_s
+        with self._condition:
+            while True:
+                self._raise_if_unavailable()
+                existing = self._leases.get(episode_id)
+                if existing is not None:
+                    if existing.seed != seed:
+                        raise ValueError(
+                            f'Episode {episode_id!r} changed seed from '
+                            f'{existing.seed} to {seed}')
+                    return existing, False
+
+                worker_index = self._find_free_worker()
+                if worker_index is not None:
+                    lease = _EpisodeLease(worker_index=worker_index, seed=seed)
+                    self._leases[episode_id] = lease
+                    self._worker_episodes[worker_index] = episode_id
+                    self._next_worker = (worker_index + 1) % self.worker_count
+                    return lease, True
+
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError(
+                        'Timed out waiting for a free inference worker; '
+                        f'{self.worker_count} workers are serving episodes '
+                        f'{sorted(self._leases)}')
+                self._condition.wait(remaining)
+
+    def _find_free_worker(self) -> int | None:
+        for offset in range(self.worker_count):
+            index = (self._next_worker + offset) % self.worker_count
+            if self._worker_episodes[index] is None:
+                return index
+        return None
+
+    def _raise_if_unavailable(self) -> None:
+        if self._closed:
+            raise RuntimeError('FluxVLA inference worker pool is closed')
+        if self._fatal_error is not None:
+            raise self._fatal_error
+
+
+class _ProcessPolicyBackend:
+    """Synchronous IPC proxy for one spawned policy process."""
+
+    def __init__(self, process: Any, connection: Connection, device: str,
+                 request_timeout_s: float) -> None:
+        self.process = process
+        self.connection = connection
+        self.device = device
+        self.request_timeout_s = request_timeout_s
+        self._lock = threading.RLock()
+        self._request_sequence = 0
+        self._closed = False
+
+    def predict(self, observation: Any, unnorm_key: str,
+                seed: int) -> tuple[np.ndarray, float]:
+        with self._lock:
+            self._ensure_alive()
+            self._request_sequence += 1
+            request_id = self._request_sequence
+            try:
+                self.connection.send({
+                    'op': 'predict',
+                    'request_id': request_id,
+                    'observation': observation,
+                    'unnorm_key': unnorm_key,
+                    'seed': seed,
+                })
+            except (BrokenPipeError, EOFError, OSError) as exc:
+                raise RuntimeError(
+                    f'Inference worker on {self.device} disconnected') from exc
+            if not self.connection.poll(self.request_timeout_s):
+                raise TimeoutError(
+                    f'Inference worker on {self.device} exceeded '
+                    f'{self.request_timeout_s:g}s request timeout')
+            try:
+                response = self.connection.recv()
+            except (EOFError, OSError) as exc:
+                raise RuntimeError(
+                    f'Inference worker on {self.device} disconnected') from exc
+            if response.get('request_id') != request_id:
+                raise RuntimeError(
+                    f'Inference worker on {self.device} returned an '
+                    'out-of-order response')
+            if response.get('op') == 'error':
+                raise RuntimeError(
+                    f"{response.get('error', 'unknown worker error')}\n"
+                    f"{response.get('traceback', '')}".rstrip())
+            if response.get('op') != 'result':
+                raise RuntimeError(
+                    f'Inference worker on {self.device} returned an invalid '
+                    f"message {response.get('op')!r}")
+            actions = np.asarray(response['actions'], dtype=np.float32)
+            return actions, float(response['inference_time_s'])
+
+    def close(self) -> None:
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            if self.process.is_alive():
+                try:
+                    self.connection.send({'op': 'shutdown'})
+                    if self.connection.poll(2.0):
+                        self.connection.recv()
+                except (BrokenPipeError, EOFError, OSError):
+                    pass
+            self.connection.close()
+        self.process.join(timeout=5.0)
+        if self.process.is_alive():
+            self.process.terminate()
+            self.process.join(timeout=5.0)
+
+    def _ensure_alive(self) -> None:
+        if self._closed:
+            raise RuntimeError(f'Inference worker on {self.device} is closed')
+        if not self.process.is_alive():
+            raise RuntimeError(
+                f'Inference worker on {self.device} exited with code '
+                f'{self.process.exitcode}')
+
+
+def spawn_ros_policy_pool(
+        cfg: Any,
+        ckpt_path: str,
+        devices: Sequence[str],
+        service_name: str | None = None,
+        startup_timeout_s: float = 900.0,
+        request_timeout_s: float = 120.0,
+        lease_timeout_s: float = 900.0) -> EpisodeAffinityPolicyPool:
+    """Spawn one fully initialized FluxVLA policy process per device."""
+    normalized_devices = tuple(str(device) for device in devices)
+    if len(normalized_devices) < 2:
+        raise ValueError('A process worker pool requires at least two devices')
+    for name, value in {
+            'startup_timeout_s': startup_timeout_s,
+            'request_timeout_s': request_timeout_s,
+            'lease_timeout_s': lease_timeout_s,
+    }.items():
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(f'{name} must be a number')
+        if value <= 0:
+            raise ValueError(f'{name} must be positive')
+
+    context = mp.get_context('spawn')
+    backends: list[_ProcessPolicyBackend] = []
+    pending_process = None
+    pending_connection = None
+    try:
+        # Start sequentially to avoid multiplying checkpoint deserialization
+        # peaks in host memory.
+        for worker_index, device in enumerate(normalized_devices):
+            print(
+                '[FluxVLA] Loading inference replica '
+                f'{worker_index + 1}/{len(normalized_devices)} on {device}.',
+                flush=True,
+            )
+            parent_connection, child_connection = context.Pipe(duplex=True)
+            process = context.Process(
+                target=_ros_policy_worker_main,
+                args=(
+                    child_connection,
+                    cfg,
+                    str(ckpt_path),
+                    device,
+                    service_name,
+                    worker_index,
+                ),
+                name=f'fluxvla-ros-worker-{worker_index}',
+            )
+            try:
+                process.start()
+            except BaseException:
+                parent_connection.close()
+                child_connection.close()
+                raise
+            child_connection.close()
+            pending_process = process
+            pending_connection = parent_connection
+            if not parent_connection.poll(float(startup_timeout_s)):
+                process.terminate()
+                process.join(timeout=5.0)
+                parent_connection.close()
+                raise TimeoutError(
+                    f'Worker {worker_index} on {device} did not become '
+                    f'ready within {startup_timeout_s:g}s')
+            try:
+                ready = parent_connection.recv()
+            except (EOFError, OSError) as exc:
+                process.join(timeout=1.0)
+                parent_connection.close()
+                raise RuntimeError(
+                    f'FluxVLA worker {worker_index} on {device} exited during '
+                    'startup') from exc
+            if ready.get('op') != 'ready':
+                process.join(timeout=1.0)
+                if process.is_alive():
+                    process.terminate()
+                    process.join(timeout=5.0)
+                parent_connection.close()
+                raise RuntimeError(
+                    f'FluxVLA worker {worker_index} on {device} failed to '
+                    f"start: {ready.get('error', 'unknown error')}\n"
+                    f"{ready.get('traceback', '')}".rstrip())
+            backends.append(
+                _ProcessPolicyBackend(
+                    process=process,
+                    connection=parent_connection,
+                    device=device,
+                    request_timeout_s=float(request_timeout_s),
+                ))
+            pending_process = None
+            pending_connection = None
+            print(
+                '[FluxVLA] Inference replica '
+                f'{worker_index + 1}/{len(normalized_devices)} ready on '
+                f'{device}.',
+                flush=True,
+            )
+        return EpisodeAffinityPolicyPool(
+            backends=backends,
+            lease_timeout_s=float(lease_timeout_s),
+        )
+    except BaseException:
+        if pending_connection is not None:
+            try:
+                pending_connection.close()
+            except OSError:
+                pass
+        if pending_process is not None:
+            try:
+                if pending_process.is_alive():
+                    pending_process.terminate()
+                if pending_process.pid is not None:
+                    pending_process.join(timeout=5.0)
+            except (AssertionError, OSError):
+                pass
+        for backend in backends:
+            try:
+                backend.close()
+            except Exception:
+                pass
+        raise
+
+
+def _ros_policy_worker_main(connection: Connection, cfg: Any, ckpt_path: str,
+                            device: str, service_name: str | None,
+                            worker_index: int) -> None:
+    """Child entry point.  Import model-building code only after spawn."""
+    policy = None
+    try:
+        import torch
+
+        worker_device = torch.device(device)
+        if worker_device.type == 'cuda':
+            # Select the replica device before any model/backbone constructor
+            # can allocate CUDA state.
+            torch.cuda.set_device(worker_device)
+        from .ros_server import build_ros_policy_from_config
+
+        policy = build_ros_policy_from_config(
+            cfg,
+            ckpt_path=ckpt_path,
+            device=device,
+            service_name=service_name,
+        )
+        connection.send({
+            'op': 'ready',
+            'worker_index': worker_index,
+            'device': device,
+        })
+        while True:
+            message = connection.recv()
+            operation = message.get('op')
+            if operation == 'shutdown':
+                connection.send({'op': 'shutdown_ack'})
+                break
+            if operation != 'predict':
+                connection.send({
+                    'op':
+                    'error',
+                    'request_id':
+                    message.get('request_id'),
+                    'error':
+                    f'Unsupported worker operation {operation!r}',
+                })
+                continue
+            request_id = message.get('request_id')
+            try:
+                actions, inference_time_s = policy.predict(
+                    message['observation'],
+                    unnorm_key=message['unnorm_key'],
+                    seed=message['seed'],
+                )
+                connection.send({
+                    'op': 'result',
+                    'request_id': request_id,
+                    'actions': actions,
+                    'inference_time_s': inference_time_s,
+                })
+            except BaseException as exc:
+                connection.send({
+                    'op': 'error',
+                    'request_id': request_id,
+                    'error': f'{type(exc).__name__}: {exc}',
+                    'traceback': traceback.format_exc(),
+                })
+    except (EOFError, KeyboardInterrupt):
+        pass
+    except BaseException as exc:
+        try:
+            connection.send({
+                'op': 'startup_error' if policy is None else 'fatal_error',
+                'error': f'{type(exc).__name__}: {exc}',
+                'traceback': traceback.format_exc(),
+            })
+        except (BrokenPipeError, EOFError, OSError):
+            pass
+    finally:
+        close = getattr(policy, 'close', None)
+        if callable(close):
+            try:
+                close()
+            except Exception:
+                pass
+        connection.close()

--- a/scripts/ros_inference_server.py
+++ b/scripts/ros_inference_server.py
@@ -30,6 +30,17 @@ def parse_args():
     parser.add_argument('--config', required=True)
     parser.add_argument('--ckpt-path', default=None)
     parser.add_argument('--device', default=None)
+    worker_group = parser.add_mutually_exclusive_group()
+    worker_group.add_argument(
+        '--num-workers',
+        type=int,
+        default=None,
+        help='Number of full-model inference replicas on cuda:0..cuda:N-1.')
+    worker_group.add_argument(
+        '--devices',
+        type=_parse_devices,
+        default=None,
+        help='Comma-separated inference devices, for example cuda:0,cuda:1.')
     parser.add_argument('--service-name', default=None)
     parser.add_argument('--node-name', default=None)
     parser.add_argument(
@@ -43,6 +54,15 @@ def parse_args():
     return parser.parse_args()
 
 
+def _parse_devices(value: str) -> tuple[str, ...]:
+    devices = tuple(item.strip() for item in value.split(',') if item.strip())
+    if not devices:
+        raise argparse.ArgumentTypeError('--devices cannot be empty')
+    if len(devices) != len(set(devices)):
+        raise argparse.ArgumentTypeError('--devices cannot contain duplicates')
+    return devices
+
+
 def main() -> int:
     args = parse_args()
     configure_inference_attention_defaults()
@@ -54,6 +74,8 @@ def main() -> int:
         cfg,
         ckpt_path=args.ckpt_path,
         device=args.device,
+        worker_devices=args.devices,
+        num_workers=args.num_workers,
         service_name=args.service_name,
         node_name=args.node_name,
         ros_version=args.ros_version,
@@ -63,6 +85,10 @@ def main() -> int:
         server.run()
     except KeyboardInterrupt:
         pass
+    finally:
+        close = getattr(server, 'close', None)
+        if callable(close):
+            close()
     return 0
 
 

--- a/scripts/ros_inference_server.py
+++ b/scripts/ros_inference_server.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+# Copyright 2026 Limx Dynamics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Launch FluxVLA inference as a FluxThemis ROS 1 or ROS 2 service."""
+
+import argparse
+
+from mmengine import Config, DictAction
+
+from fluxvla.engines.runners.serving.ros_server import \
+    build_ros_server_from_config
+from fluxvla.engines.utils.torch_utils import \
+    configure_inference_attention_defaults
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='Serve FluxVLA inference to FluxThemis through ROS.')
+    parser.add_argument('--config', required=True)
+    parser.add_argument('--ckpt-path', default=None)
+    parser.add_argument('--device', default=None)
+    parser.add_argument('--service-name', default=None)
+    parser.add_argument('--node-name', default=None)
+    parser.add_argument(
+        '--ros-version',
+        type=int,
+        choices=(1, 2),
+        default=None,
+        help='ROS transport version; overrides themis.ros_server.ros_version.')
+    parser.add_argument(
+        '--cfg-options', nargs='+', action=DictAction, default=None)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    configure_inference_attention_defaults()
+    cfg = Config.fromfile(args.config)
+    if args.cfg_options:
+        cfg.merge_from_dict(args.cfg_options)
+
+    server = build_ros_server_from_config(
+        cfg,
+        ckpt_path=args.ckpt_path,
+        device=args.device,
+        service_name=args.service_name,
+        node_name=args.node_name,
+        ros_version=args.ros_version,
+    )
+    try:
+        server.run()
+    except KeyboardInterrupt:
+        pass
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/ros_inference_server.py
+++ b/scripts/ros_inference_server.py
@@ -57,6 +57,7 @@ def main() -> int:
         service_name=args.service_name,
         node_name=args.node_name,
         ros_version=args.ros_version,
+        config_path=args.config,
     )
     try:
         server.run()

--- a/scripts/ros_inference_server.sh
+++ b/scripts/ros_inference_server.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Copyright 2026 Limx Dynamics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Stable shell entry point for the FluxThemis ROS inference service. The
+# Python module remains the single owner of argument parsing and server logic.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${PROJECT_ROOT}"
+exec python "${SCRIPT_DIR}/ros_inference_server.py" "$@"


### PR DESCRIPTION
## Summary

  This PR adds FluxThemis integration to FluxVLA, including ROS 1/ROS 2 policy serving, episode-
  affine multi-GPU inference, and native LIBERO/RoboCasa evaluation reporting.

  ## Key Changes

  - Added a config-driven ROS inference launcher supporting ROS 1 and ROS 2.
  - Added strict request validation, preprocessing, checkpoint loading, mixed-precision inference,
  and action denormalization.
  - Added multi-device serving with one full model replica per GPU and stable episode-to-worker
  affinity.
  - Added acknowledged evaluation lifecycle reporting for `run_start`, `episode_start`,
  `episode_end`, and `run_end`.
  - Added durable event journals, progress files, native FluxVLA summaries, and best-effort full-
  suite Feishu reporting.
  - Added FluxThemis configuration to PI0.5 LIBERO-10, PI0.5 RoboCasa, and GR00T RoboCasa evaluation
  configs.
  - Updated Feishu reporting documentation with ROS evaluation setup, output layout, and reporting
  requirements.
  - Kept ROS imports lazy so existing training, evaluation, and ZMQ serving workflows do not require
  ROS dependencies.

  ## Validation

  - `git diff --check main...HEAD`: passed.
  - Syntax checks passed for all changed Python files.
  - All four modified MMEngine configs load successfully.
  - ROS launcher help and serving-package lazy imports were verified.
  - Existing lightweight tests: `11 passed`.
  - End-to-end ROS service exchange, checkpoint inference, and multi-GPU execution were not run.

  ## Notes

  - Multi-GPU serving uses full-model replication rather than model sharding.
  - Multi-worker mode requires evaluation lifecycle reporting to release episode leases safely.
  - ROS 1 remains the default, and the provided configs remain single-worker by default.
  - ROS and generated `fluxthemis_msgs` interfaces must be supplied by the deployment environment.