### PR TITLE
docs: add fluxvla agent paper citation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1029,6 +1029,13 @@ If you use FluxVLA in your research or projects, please cite the relevant works 
     year      = {2026},
     pages     = {4468-4477}
 }
+
+@article{Huang_2026_IROS,
+  title={Long-Term Memory for VLA-based Agents in Open-World Task Execution},
+  author={Huang, Xu and Mao, Weixin and Li, Yinhao and Chen, Hua and Zhao, Jiabao},
+  journal={arXiv preprint arXiv:2604.15671},
+  year={2026}
+}
 ```
 
 **Acknowledgements:** This project benefits from the following open-source projects and community efforts. Thanks to: [LeRobot](https://github.com/huggingface/lerobot), [NVIDIA Isaac GR00T](https://github.com/NVIDIA/Isaac-GR00T/tree/main), [DreamZero](https://arxiv.org/abs/2602.15922) ([code](https://github.com/dreamzero0/dreamzero)), [OpenVLA](https://github.com/openvla/openvla), [OpenPI (pi0)](https://github.com/Physical-Intelligence/openpi), [LLaVA](https://github.com/haotian-liu/LLaVA), [DeepSpeed](https://github.com/deepspeedai/DeepSpeed), [Qwen](https://github.com/QwenLM), [Triton](https://github.com/triton-lang/triton), [RTC](https://github.com/Physical-Intelligence/real-time-chunking-kinetix), [Training RTC](https://arxiv.org/pdf/2512.05964), and [Realtime-VLA](https://github.com/Dexmal/realtime-vla). If we missed your project or contribution, please open an issue or pull request so we can properly acknowledge it.

--- a/README_ja.md
+++ b/README_ja.md
@@ -970,6 +970,13 @@ FluxVLA を研究やプロジェクトで利用した場合は、以下の文献
     year      = {2026},
     pages     = {4468-4477}
 }
+
+@article{Huang_2026_IROS,
+  title={Long-Term Memory for VLA-based Agents in Open-World Task Execution},
+  author={Huang, Xu and Mao, Weixin and Li, Yinhao and Chen, Hua and Zhao, Jiabao},
+  journal={arXiv preprint arXiv:2604.15671},
+  year={2026}
+}
 ```
 
 **謝辞:** 本プロジェクトは、以下のオープンソースプロジェクトおよびコミュニティの活動から恩恵を受けています。心より感謝いたします：[LeRobot](https://github.com/huggingface/lerobot)、[NVIDIA Isaac GR00T](https://github.com/NVIDIA/Isaac-GR00T/tree/main)、[DreamZero](https://arxiv.org/abs/2602.15922)（[code](https://github.com/dreamzero0/dreamzero)）、[OpenVLA](https://github.com/openvla/openvla)、[OpenPI (pi0)](https://github.com/Physical-Intelligence/openpi)、[LLaVA](https://github.com/haotian-liu/LLaVA)、[DeepSpeed](https://github.com/deepspeedai/DeepSpeed)、[Qwen](https://github.com/QwenLM)、[Triton](https://github.com/triton-lang/triton)、[RTC](https://github.com/Physical-Intelligence/real-time-chunking-kinetix)、[Training RTC](https://arxiv.org/pdf/2512.05964)、[Realtime-VLA](https://github.com/Dexmal/realtime-vla)。もし謝辞に漏れがありましたら、issue または pull request でお知らせください。適切に謝辞へ反映します。

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -964,6 +964,13 @@ pip install numpy==1.26.4
     year      = {2026},
     pages     = {4468-4477}
 }
+
+@article{Huang_2026_IROS,
+  title={Long-Term Memory for VLA-based Agents in Open-World Task Execution},
+  author={Huang, Xu and Mao, Weixin and Li, Yinhao and Chen, Hua and Zhao, Jiabao},
+  journal={arXiv preprint arXiv:2604.15671},
+  year={2026}
+}
 ```
 
 **致谢**：本项目受益于以下开源项目与社区工作，在此一并致谢：[LeRobot](https://github.com/huggingface/lerobot)、[NVIDIA Isaac GR00T](https://github.com/NVIDIA/Isaac-GR00T/tree/main)、[DreamZero](https://arxiv.org/abs/2602.15922)（[代码](https://github.com/dreamzero0/dreamzero)）、[OpenVLA](https://github.com/openvla/openvla)、[OpenPI (pi0)](https://github.com/Physical-Intelligence/openpi)、[LLaVA](https://github.com/haotian-liu/LLaVA)、[DeepSpeed](https://github.com/deepspeedai/DeepSpeed)、[Qwen](https://github.com/QwenLM)、[Triton](https://github.com/triton-lang/triton)、[RTC](https://github.com/Physical-Intelligence/real-time-chunking-kinetix)、[Training RTC](https://arxiv.org/pdf/2512.05964)、[Realtime-VLA](https://github.com/Dexmal/realtime-vla)。如果我们不慎遗漏了您的项目或贡献，请提交 issue 或 pull request，以便我们能够给予您应有的致谢。


### PR DESCRIPTION
## Summary

  Add citation information for our paper:

  **ChemBot: Long-Term Memory for VLA-based Agents in Open-World Task Execution**

  ChemBot is a dual-layer closed-loop framework for chemical laboratory automation. It combines an autonomous AI agent with a progress-aware VLA model for hierarchical task planning and execution, and uses persistent memory to reuse successful trajectories. The paper also introduces MCP-based tool orchestration and asynchronous future-state inference to improve long-horizon task continuity, safety, precision, and success rates.

  ## Changes

  - Add the paper's BibTeX citation to:
    - `README.md`
    - `README_zh-CN.md`
    - `README_ja.md`

  ## Testing

  - Documentation-only change; no runtime tests required.