### PR TITLE
[Fix] Align PI0.5 state prompt tokenization

### DIFF
--- a/configs/pi05/fluxbisim/pi05_paligemma_close_box_full_finetune.py
+++ b/configs/pi05/fluxbisim/pi05_paligemma_close_box_full_finetune.py
@@ -162,10 +162,11 @@ train_dataloader = dict(
                         state_key='proprio',
                         action_key='action',
                         norm_type='mean_std'),
-                    dict(type='PreparePromptWithState'),
+                    dict(type='PreparePromptWithState', token_state_dim=14),
                     dict[str, str | dict[str, str]](
                         type='ProcessPrompts',
                         max_len=200,
+                        preserve_suffix_after=', State: ',
                         tokenizer=dict(
                             type='PretrainedTokenizer',
                             model_path=  # noqa: E251
@@ -241,9 +242,11 @@ inference = dict(
                 state_key='proprio',
                 action_key='action',
                 norm_type='mean_std'),
-            dict(type='PreparePromptWithState'),
+            dict(type='PreparePromptWithState', token_state_dim=14),
             dict[str, str | dict[str, str]](
                 type='ProcessPrompts',
+                max_len=200,
+                preserve_suffix_after=', State: ',
                 tokenizer=dict(
                     type='PretrainedTokenizer',
                     model_path=  # noqa: E251

--- a/configs/pi05/fluxbisim/pi05_paligemma_handover_book_full_finetune.py
+++ b/configs/pi05/fluxbisim/pi05_paligemma_handover_book_full_finetune.py
@@ -162,10 +162,11 @@ train_dataloader = dict(
                         state_key='proprio',
                         action_key='action',
                         norm_type='mean_std'),
-                    dict(type='PreparePromptWithState'),
+                    dict(type='PreparePromptWithState', token_state_dim=14),
                     dict[str, str | dict[str, str]](
                         type='ProcessPrompts',
                         max_len=200,
+                        preserve_suffix_after=', State: ',
                         tokenizer=dict(
                             type='PretrainedTokenizer',
                             model_path=  # noqa: E251
@@ -241,9 +242,11 @@ inference = dict(
                 state_key='proprio',
                 action_key='action',
                 norm_type='mean_std'),
-            dict(type='PreparePromptWithState'),
+            dict(type='PreparePromptWithState', token_state_dim=14),
             dict[str, str | dict[str, str]](
                 type='ProcessPrompts',
+                max_len=200,
+                preserve_suffix_after=', State: ',
                 tokenizer=dict(
                     type='PretrainedTokenizer',
                     model_path=  # noqa: E251

--- a/configs/pi05/fluxbisim/pi05_paligemma_pick_place_banana_full_finetune.py
+++ b/configs/pi05/fluxbisim/pi05_paligemma_pick_place_banana_full_finetune.py
@@ -162,10 +162,11 @@ train_dataloader = dict(
                         state_key='proprio',
                         action_key='action',
                         norm_type='mean_std'),
-                    dict(type='PreparePromptWithState'),
+                    dict(type='PreparePromptWithState', token_state_dim=14),
                     dict[str, str | dict[str, str]](
                         type='ProcessPrompts',
                         max_len=200,
+                        preserve_suffix_after=', State: ',
                         tokenizer=dict(
                             type='PretrainedTokenizer',
                             model_path=  # noqa: E251
@@ -241,9 +242,11 @@ inference = dict(
                 state_key='proprio',
                 action_key='action',
                 norm_type='mean_std'),
-            dict(type='PreparePromptWithState'),
+            dict(type='PreparePromptWithState', token_state_dim=14),
             dict[str, str | dict[str, str]](
                 type='ProcessPrompts',
+                max_len=200,
+                preserve_suffix_after=', State: ',
                 tokenizer=dict(
                     type='PretrainedTokenizer',
                     model_path=  # noqa: E251

--- a/configs/pi05/fluxbisim/pi05_paligemma_pull_push_drawer_full_finetune.py
+++ b/configs/pi05/fluxbisim/pi05_paligemma_pull_push_drawer_full_finetune.py
@@ -162,10 +162,11 @@ train_dataloader = dict(
                         state_key='proprio',
                         action_key='action',
                         norm_type='mean_std'),
-                    dict(type='PreparePromptWithState'),
+                    dict(type='PreparePromptWithState', token_state_dim=14),
                     dict[str, str | dict[str, str]](
                         type='ProcessPrompts',
                         max_len=200,
+                        preserve_suffix_after=', State: ',
                         tokenizer=dict(
                             type='PretrainedTokenizer',
                             model_path=  # noqa: E251
@@ -241,9 +242,11 @@ inference = dict(
                 state_key='proprio',
                 action_key='action',
                 norm_type='mean_std'),
-            dict(type='PreparePromptWithState'),
+            dict(type='PreparePromptWithState', token_state_dim=14),
             dict[str, str | dict[str, str]](
                 type='ProcessPrompts',
+                max_len=200,
+                preserve_suffix_after=', State: ',
                 tokenizer=dict(
                     type='PretrainedTokenizer',
                     model_path=  # noqa: E251

--- a/configs/pi05/fluxbisim/pi05_paligemma_screw_pitcher_lid_full_finetune.py
+++ b/configs/pi05/fluxbisim/pi05_paligemma_screw_pitcher_lid_full_finetune.py
@@ -162,10 +162,11 @@ train_dataloader = dict(
                         state_key='proprio',
                         action_key='action',
                         norm_type='mean_std'),
-                    dict(type='PreparePromptWithState'),
+                    dict(type='PreparePromptWithState', token_state_dim=14),
                     dict[str, str | dict[str, str]](
                         type='ProcessPrompts',
                         max_len=200,
+                        preserve_suffix_after=', State: ',
                         tokenizer=dict(
                             type='PretrainedTokenizer',
                             model_path=  # noqa: E251
@@ -241,9 +242,11 @@ inference = dict(
                 state_key='proprio',
                 action_key='action',
                 norm_type='mean_std'),
-            dict(type='PreparePromptWithState'),
+            dict(type='PreparePromptWithState', token_state_dim=14),
             dict[str, str | dict[str, str]](
                 type='ProcessPrompts',
+                max_len=200,
+                preserve_suffix_after=', State: ',
                 tokenizer=dict(
                     type='PretrainedTokenizer',
                     model_path=  # noqa: E251

--- a/configs/pi05/pi05_paligemma_aloha+ur_4090_full_finetune.py
+++ b/configs/pi05/pi05_paligemma_aloha+ur_4090_full_finetune.py
@@ -366,10 +366,12 @@ train_dataloader = dict(
                             action_key='action',
                             norm_type='quantile',
                             output_dtype='float32'),
-                        dict(type='PreparePromptWithState'),
+                        dict(
+                            type='PreparePromptWithState', token_state_dim=14),
                         dict[str, str | dict[str, str]](
                             type='ProcessPrompts',
                             max_len=200,
+                            preserve_suffix_after=', State: ',
                             tokenizer=dict(
                                 type='PretrainedTokenizer',
                                 model_path=  # noqa: E251

--- a/configs/pi05/pi05_paligemma_aloha_full_finetune.py
+++ b/configs/pi05/pi05_paligemma_aloha_full_finetune.py
@@ -287,10 +287,11 @@ train_dataloader = dict(
                         action_key='action',
                         norm_type='quantile',
                         output_dtype='float32'),
-                    dict(type='PreparePromptWithState'),
+                    dict(type='PreparePromptWithState', token_state_dim=14),
                     dict[str, str | dict[str, str]](
                         type='ProcessPrompts',
                         max_len=200,
+                        preserve_suffix_after=', State: ',
                         tokenizer=dict(
                             type='PretrainedTokenizer',
                             model_path=  # noqa: E251
@@ -398,10 +399,11 @@ inference = dict(
                 action_key='action',
                 norm_type='quantile',
                 output_dtype='float32'),
-            dict(type='PreparePromptWithState'),
+            dict(type='PreparePromptWithState', token_state_dim=14),
             dict[str, str | dict[str, str]](
                 type='ProcessPrompts',
                 max_len=200,
+                preserve_suffix_after=', State: ',
                 tokenizer=dict(
                     type='PretrainedTokenizer',
                     model_path=  # noqa: E251

--- a/configs/pi05/pi05_paligemma_aloha_rtc_kernel_inference.py
+++ b/configs/pi05/pi05_paligemma_aloha_rtc_kernel_inference.py
@@ -399,10 +399,11 @@ train_dataloader = dict(
                         action_key='action',
                         norm_type='quantile',
                         output_dtype='float32'),
-                    dict(type='PreparePromptWithState'),
+                    dict(type='PreparePromptWithState', token_state_dim=14),
                     dict[str, str | dict[str, str]](
                         type='ProcessPrompts',
                         max_len=200,
+                        preserve_suffix_after=', State: ',
                         tokenizer=dict(
                             type='PretrainedTokenizer',
                             model_path=  # noqa: E251
@@ -513,10 +514,11 @@ inference = dict(
                 action_key='action',
                 norm_type='quantile',
                 output_dtype='float32'),
-            dict(type='PreparePromptWithState'),
+            dict(type='PreparePromptWithState', token_state_dim=14),
             dict[str, str | dict[str, str]](
                 type='ProcessPrompts',
                 max_len=200,
+                preserve_suffix_after=', State: ',
                 tokenizer=dict(
                     type='PretrainedTokenizer',
                     model_path=  # noqa: E251

--- a/fluxvla/transforms/prompters.py
+++ b/fluxvla/transforms/prompters.py
@@ -281,6 +281,10 @@ class PreparePromptWithState():
 
     Args:
         max_state_dim (int): The maximum dimension of the state.
+        token_state_dim (int, optional): Number of leading state dimensions to
+            encode in the prompt. This can be smaller than ``max_state_dim``
+            when the continuous model input is padded after normalization.
+            Defaults to ``max_state_dim`` for backward compatibility.
         task_key (str): The key of the task description in the input data.
         lowercase_task_description (bool): Whether to lowercase task text.
         add_action_prefix (bool): Whether to append ``Action:`` to the prompt.
@@ -288,12 +292,19 @@ class PreparePromptWithState():
 
     def __init__(self,
                  max_state_dim: int = 32,
+                 token_state_dim: Optional[int] = None,
                  task_key: str = 'task_description',
                  lowercase_task_description: bool = False,
                  add_action_prefix: bool = True,
                  *args,
                  **kwargs):
         self.max_state_dim = max_state_dim
+        self.token_state_dim = (
+            max_state_dim if token_state_dim is None else token_state_dim)
+        if not 0 < self.token_state_dim <= self.max_state_dim:
+            raise ValueError('token_state_dim must be in the range '
+                             f'[1, {self.max_state_dim}], got '
+                             f'{self.token_state_dim}.')
         self.task_key = task_key
         self.lowercase_task_description = lowercase_task_description
         self.add_action_prefix = add_action_prefix
@@ -314,8 +325,9 @@ class PreparePromptWithState():
         # by the NormalizerProcessorStep that runs before this step
         # Discretize into 256 bins
         # (see openpi `PaligemmaTokenizer.tokenize()`)
+        token_states = state_padded[:self.token_state_dim]
         discretized_states = np.digitize(
-            state_padded, bins=np.linspace(-1, 1, 256 + 1)[:-1]) - 1
+            token_states, bins=np.linspace(-1, 1, 256 + 1)[:-1]) - 1
 
         cleaned_text = task_description.strip().replace('_', ' ').replace(
             '\n', ' ')

--- a/fluxvla/transforms/transform_prompts.py
+++ b/fluxvla/transforms/transform_prompts.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import os
 from typing import Dict, List, Optional
 
@@ -123,6 +124,10 @@ class ProcessPrompts():
             Defaults to 180.
         with_labels (bool, optional): Whether to include labels in
             the output. Defaults to False.
+        preserve_suffix_after (str, optional): If a prompt exceeds
+            ``max_len``, preserve the suffix beginning at the last occurrence
+            of this marker and truncate only the preceding text. This is used
+            by PI0.5 to retain the complete state and ``Action:`` marker.
     """
 
     def __init__(self,
@@ -132,7 +137,8 @@ class ProcessPrompts():
                  with_labels: bool = False,
                  with_state: bool = False,
                  ignore_index: int = -100,
-                 negative_prompt=None):
+                 negative_prompt=None,
+                 preserve_suffix_after: str | None = None):
         from fluxvla.engines import build_tokenizer_from_cfg
         if model_path is not None:
             tokenizer['model_path'] = os.path.join(model_path, 'tokenizer')
@@ -142,19 +148,64 @@ class ProcessPrompts():
         self.with_state = with_state
         self.ignore_index = ignore_index
         self.negative_prompt = negative_prompt
+        self.preserve_suffix_after = preserve_suffix_after
+
+    def _encode_prompt(self, prompt: str, state: np.ndarray | None = None):
+        if state is not None:
+            return self.tokenizer(
+                prompt, state=state, add_special_tokens=True)['input_ids']
+        return self.tokenizer(prompt, add_special_tokens=True)['input_ids']
+
+    def _truncate_preserving_suffix(self, prompt: str,
+                                    state: np.ndarray | None):
+        marker_index = prompt.rfind(self.preserve_suffix_after)
+        if marker_index < 0:
+            raise ValueError(
+                'Prompt does not contain the configured protected suffix '
+                f'marker {self.preserve_suffix_after!r}.')
+
+        head = prompt[:marker_index]
+        suffix = prompt[marker_index:]
+        suffix_tokens = self._encode_prompt(suffix, state)
+        if len(suffix_tokens) > self.max_len:
+            raise ValueError(
+                f'Protected prompt suffix needs {len(suffix_tokens)} tokens, '
+                f'which exceeds max_len={self.max_len}.')
+
+        low, high = 0, len(head)
+        best_tokens = suffix_tokens
+        best_prompt = suffix
+        while low <= high:
+            midpoint = (low + high) // 2
+            candidate = head[:midpoint].rstrip() + suffix
+            candidate_tokens = self._encode_prompt(candidate, state)
+            if len(candidate_tokens) <= self.max_len:
+                best_tokens = candidate_tokens
+                best_prompt = candidate
+                low = midpoint + 1
+            else:
+                high = midpoint - 1
+
+        logging.warning(
+            'Prompt exceeds max_len=%d; truncated task text while preserving '
+            'the suffix beginning with %r.', self.max_len,
+            self.preserve_suffix_after)
+        return best_tokens, best_prompt
 
     def _tokenize_single_prompt(self,
                                 prompt: str,
                                 state: np.ndarray | None = None):
-        if state is not None:
-            tokens = self.tokenizer(
-                prompt, state=state, add_special_tokens=True)['input_ids']
-        else:
-            tokens = self.tokenizer(
-                prompt, add_special_tokens=True)['input_ids']
+        effective_prompt = prompt
+        tokens = self._encode_prompt(prompt, state)
         token_mask = [True] * len(tokens)
         tokens_len = len(tokens)
         if self.max_len is not None:
+            if (tokens_len > self.max_len
+                    and self.preserve_suffix_after is not None):
+                tokens, effective_prompt = self._truncate_preserving_suffix(
+                    prompt, state)
+                token_mask = [True] * len(tokens)
+                tokens_len = len(tokens)
             if tokens_len < self.max_len:
                 padding = [False] * (self.max_len - tokens_len)
                 tokens = tokens + padding
@@ -162,7 +213,7 @@ class ProcessPrompts():
             else:
                 tokens = tokens[:self.max_len]
                 token_mask = token_mask[:self.max_len]
-        return tokens, token_mask
+        return tokens, token_mask, effective_prompt
 
     def __call__(self, inputs):
         """Tokenize and process the prompt in the input data.
@@ -179,12 +230,13 @@ class ProcessPrompts():
             state = inputs['state']
         else:
             state = None
-        tokens, token_mask = self._tokenize_single_prompt(
+        tokens, token_mask, effective_prompt = self._tokenize_single_prompt(
             inputs['prompt'], state)
+        inputs['prompt'] = effective_prompt
         lang_tokens = [tokens]
         lang_masks = [token_mask]
         if self.negative_prompt is not None:
-            negative_tokens, negative_token_mask = (
+            negative_tokens, negative_token_mask, _ = (
                 self._tokenize_single_prompt(self.negative_prompt, state))
             lang_tokens.append(negative_tokens)
             lang_masks.append(negative_token_mask)

--- a/test/test_configs/test_pi05_prompt_config.py
+++ b/test/test_configs/test_pi05_prompt_config.py
@@ -1,0 +1,58 @@
+# Copyright 2026 Limx Dynamics
+
+from mmengine import Config
+
+FLUXBISIM_CONFIGS = [
+    'configs/pi05/fluxbisim/pi05_paligemma_close_box_full_finetune.py',
+    'configs/pi05/fluxbisim/pi05_paligemma_handover_book_full_finetune.py',
+    'configs/pi05/fluxbisim/pi05_paligemma_pick_place_banana_full_finetune.py',
+    'configs/pi05/fluxbisim/pi05_paligemma_pull_push_drawer_full_finetune.py',
+    'configs/pi05/fluxbisim/pi05_paligemma_screw_pitcher_lid_full_finetune.py',
+]
+
+
+def _get_transform(transforms, transform_type):
+    return next(transform for transform in transforms
+                if transform.type == transform_type)
+
+
+def _assert_aloha_prompt_contract(transforms):
+    prepare = _get_transform(transforms, 'PreparePromptWithState')
+    process = _get_transform(transforms, 'ProcessPrompts')
+
+    assert prepare.token_state_dim == 14
+    assert process.max_len == 200
+    assert process.preserve_suffix_after == ', State: '
+
+
+def test_pi05_aloha_train_and_eval_preserve_the_openpi_prompt_contract():
+    cfg = Config.fromfile('configs/pi05/pi05_paligemma_aloha_full_finetune.py')
+
+    train_transforms = cfg.train_dataloader.dataset.datasets[0].transforms
+    _assert_aloha_prompt_contract(train_transforms)
+    _assert_aloha_prompt_contract(cfg.inference.dataset.transforms)
+
+
+def test_pi05_aloha_rtc_train_and_inference_use_the_same_prompt_contract():
+    cfg = Config.fromfile(
+        'configs/pi05/pi05_paligemma_aloha_rtc_kernel_inference.py')
+
+    train_transforms = cfg.train_dataloader.dataset.datasets[0].transforms
+    _assert_aloha_prompt_contract(train_transforms)
+    _assert_aloha_prompt_contract(cfg.inference.dataset.transforms)
+
+
+def test_pi05_mixed_training_keeps_the_aloha_state_at_14_dimensions():
+    cfg = Config.fromfile(
+        'configs/pi05/pi05_paligemma_aloha+ur_4090_full_finetune.py')
+
+    transforms = cfg.train_dataloader.dataset.datasets.aloha[0].transforms
+    _assert_aloha_prompt_contract(transforms)
+
+
+def test_pi05_fluxbisim_configs_use_the_14d_aloha_prompt_contract():
+    for config_path in FLUXBISIM_CONFIGS:
+        cfg = Config.fromfile(config_path)
+        train_transforms = cfg.train_dataloader.dataset.datasets[0].transforms
+        _assert_aloha_prompt_contract(train_transforms)
+        _assert_aloha_prompt_contract(cfg.inference.dataset.transforms)

--- a/test/test_transforms/test_pi05_prompt_transforms.py
+++ b/test/test_transforms/test_pi05_prompt_transforms.py
@@ -1,0 +1,76 @@
+# Copyright 2026 Limx Dynamics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+from fluxvla.engines.utils import TOKENIZERS
+from fluxvla.transforms.prompters import PreparePromptWithState
+from fluxvla.transforms.transform_prompts import ProcessPrompts
+
+
+@TOKENIZERS.register_module(name='CharacterTokenizerForPromptTest', force=True)
+class _CharacterTokenizer:
+    """Minimal tokenizer that makes truncation behavior directly observable."""
+
+    def __call__(self, prompt, add_special_tokens=True, **kwargs):
+        tokens = [1] if add_special_tokens else []
+        tokens.extend(ord(character) for character in prompt)
+        return {'input_ids': tokens}
+
+
+def _decode_character_tokens(tokens, mask):
+    valid_tokens = np.asarray(tokens)[np.asarray(mask, dtype=bool)]
+    return ''.join(chr(token) for token in valid_tokens[1:])
+
+
+def test_pi05_prompt_tokenizes_only_the_configured_state_dimensions():
+    states = np.zeros(32, dtype=np.float32)
+    states[0] = -1.0
+    states[13] = 1.0
+    original_states = states.copy()
+    transform = PreparePromptWithState(max_state_dim=32, token_state_dim=14)
+
+    output = transform({
+        'states': states,
+        'task_description': 'Move_the_block',
+    })
+
+    assert output['prompt'] == (
+        'Task: Move the block, State: '
+        '0 128 128 128 128 128 128 128 128 128 128 128 128 255;\n'
+        'Action: ')
+    np.testing.assert_array_equal(output['states'], original_states)
+
+
+def test_pi05_long_prompt_truncates_task_and_preserves_state_suffix():
+    prepare = PreparePromptWithState(max_state_dim=32, token_state_dim=3)
+    process = ProcessPrompts(
+        tokenizer={'type': 'CharacterTokenizerForPromptTest'},
+        max_len=52,
+        preserve_suffix_after=', State: ',
+    )
+    task = 'move every block to the matching container ' * 8
+    data = prepare({
+        'states': np.array([-1.0, 0.0, 1.0] + [0.0] * 29),
+        'task_description': task,
+    })
+
+    output = process(data)
+    decoded = _decode_character_tokens(output['lang_tokens'],
+                                       output['lang_masks'])
+
+    assert output['lang_masks'].sum() <= 52
+    assert decoded.startswith('Task: move every')
+    assert decoded.endswith(', State: 0 128 255;\nAction: ')
+    assert decoded == output['prompt']


### PR DESCRIPTION
## Summary

- Add `token_state_dim` to `PreparePromptWithState` so PI0.5 can tokenize the real 14D ALOHA state while keeping the continuous model state padded to 32D.
- Add tokenizer-aware prompt truncation that shortens only the task text and preserves the complete `, State: ...;\nAction: ` suffix.
- Keep the emitted `prompt` metadata synchronized with the text actually sent to the tokenizer.
- Enable the OpenPI-compatible contract in the ALOHA, ALOHA RTC, mixed ALOHA, and 14D FluxBiSim train/inference configs; align FluxBiSim inference to the PI0.5 200-token budget.

## Why

OpenPI tokenizes the normalized real robot state before padding the continuous state/action tensors. FluxVLA previously padded the state to 32D first, so 18 structural zeros became 72 extra SentencePiece tokens (`128` bins): 138 valid prompt tokens instead of OpenPI's 66 on the same sample.

The existing generic right truncation also removed the state and `Action:` tail first when a task instruction exceeded the prompt budget.

## Validation

- `12 passed`: all transform tests plus the new PI0.5 config contract tests.
- Repository pre-commit hooks pass on every changed file.
- Real 14D ALOHA/XDOF sample: FluxVLA token IDs, token mask, and 32D continuous state are elementwise identical to OpenPI; valid prompt tokens drop from 138 to 66.
- A 5,352-character task is reduced to exactly 200 valid tokens while retaining the complete 14D state and `Action:` suffix.
- Full BF16/FP32 PI0.5 forward plus 10-step denoising on the fixed batch succeeds. Loss is `0.0563892089`; velocity, denoising trajectory, and final action are bit-exact with the previous canonical OpenPI-input run (`max_abs_diff = 0.0`).
