### PR TITLE
Docs: Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ FluxVLA Engine is a full-stack, end-to-end engineering platform for deploying em
 
 ## 📢 Latest News
 
+**\[2026/08/25\]** 🔥 FluxVLA-native DiT4DiT support is now available, including training and inference workflows for LIBERO and RoboCasa.
+
 **\[2026/08/20\]** 🔥 FluxVLA-native Cosmos3 support is now available for Nano, Super, and Edge, including post-training and inference workflows.
 
 **\[2026/08/13\]** 🔥 FastWAM world-action model support is now available.
@@ -814,25 +816,23 @@ For ARM and SARM workflows, you typically need a CLIP checkpoint for training / 
 <details>
 <summary><b>VLA models</b></summary>
 
-| Model                   | Size | Download link                                                                                                                        |
-| ----------------------- | ---- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| GR00T N1.5              | 3B   | [🤗 Hugging Face](https://huggingface.co/nvidia/GR00T-N1.5-3B/tree/main)                                                             |
-| OpenVLA                 | 7B   | [🤗 Hugging Face](https://huggingface.co/openvla/openvla-7b)                                                                         |
-| FastWAM_base            | 5B   | [🤗 Hugging Face](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/fastwam_base)                                          |
-| Cosmos-Predict2.5-2B    | 2B   | [🤗 Hugging Face](https://huggingface.co/nvidia/Cosmos-Predict2.5-2B)                                                                |
-| PI0_base                | 3B   | [🤗 Hugging Face](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi0_base)                                              |
-| PI0 RoboCasa full-data  | 3B   | [🤗 Hugging Face](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi0_paligemma_robocasa_full_data_full_finetune_bs256)  |
-| PI05_base               | 3B   | [🤗 Hugging Face](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi05_base)                                             |
-| PI05_libero             | 3B   | [🤗 Hugging Face](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi05_libero)                                           |
-| PI05 RoboCasa full-data | 3B   | [🤗 Hugging Face](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi05_paligemma_robocasa_full_data_full_finetune_bs256) |
-| SmolVLA                 | 450M | [🤗 Hugging Face](https://huggingface.co/lerobot/smolvla_base)                                                                       |
+| Model                  | Size | Download link                                                                                                                       |
+| ---------------------- | ---- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| GR00T N1.5             | 3B   | [🤗 Hugging Face](https://huggingface.co/nvidia/GR00T-N1.5-3B/tree/main)                                                            |
+| OpenVLA                | 7B   | [🤗 Hugging Face](https://huggingface.co/openvla/openvla-7b)                                                                        |
+| FastWAM_base           | 5B   | [🤗 Hugging Face](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/fastwam_base)                                         |
+| Cosmos-Predict2.5-2B   | 2B   | [🤗 Hugging Face](https://huggingface.co/nvidia/Cosmos-Predict2.5-2B)                                                               |
+| PI0_base               | 3B   | [🤗 Hugging Face](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi0_base)                                             |
+| PI0 RoboCasa full-data | 3B   | [🤗 Hugging Face](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi0_paligemma_robocasa_full_data_full_finetune_bs256) |
+| PI05_base              | 3B   | [🤗 Hugging Face](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi05_base)                                            |
+| PI05_libero            | 3B   | [🤗 Hugging Face](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi05_libero)                                          |
+| SmolVLA                | 450M | [🤗 Hugging Face](https://huggingface.co/lerobot/smolvla_base)                                                                      |
 
-Download the PI0 and PI0.5 RoboCasa full-data checkpoints while preserving the paths expected by their configs:
+Download the PI0 RoboCasa full-data checkpoint while preserving the path expected by its config:
 
 ```bash
 hf download limxdynamics/FluxVLAEngine \
   --include "pi0_paligemma_robocasa_full_data_full_finetune_bs256/*" \
-  --include "pi05_paligemma_robocasa_full_data_full_finetune_bs256/*" \
   --local-dir ./checkpoints
 ```
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -59,6 +59,8 @@ FluxVLA Engine は、具現知能（Embodied Intelligence）の実運用を見�
 
 ## 📢 最新情報
 
+**\[2026/08/25\]** 🔥 FluxVLA-native DiT4DiT に対応しました。LIBERO と RoboCasa の学習・推論ワークフローを含みます。
+
 **\[2026/08/20\]** 🔥 FluxVLA-native Cosmos3（Nano、Super、Edge）に対応しました。ポストトレーニングと推論ワークフローを含みます。
 
 **\[2026/08/13\]** 🔥 世界行動モデル FastWAM をサポートしました。
@@ -738,25 +740,23 @@ ARM と SARM のワークフローでは、通常は学習 / 推論用の CLIP �
 <details>
 <summary><b>VLA モデル</b></summary>
 
-| モデル                    | サイズ | ダウンロードリンク                                                                                                                   |
-| ------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------ |
-| GR00T N1.5                | 3B     | [🤗 Hugging Face](https://huggingface.co/nvidia/GR00T-N1.5-3B/tree/main)                                                             |
-| OpenVLA                   | 7B     | [🤗 Hugging Face](https://huggingface.co/openvla/openvla-7b)                                                                         |
-| FastWAM_base              | 5B     | [🤗 Hugging Face](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/fastwam_base)                                          |
-| Cosmos-Predict2.5-2B      | 2B     | [🤗 Hugging Face](https://huggingface.co/nvidia/Cosmos-Predict2.5-2B)                                                                |
-| PI0_base                  | 3B     | [🤗 Hugging Face](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi0_base)                                              |
-| PI0 RoboCasa（全データ）  | 3B     | [🤗 Hugging Face](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi0_paligemma_robocasa_full_data_full_finetune_bs256)  |
-| PI05_base                 | 3B     | [🤗 Hugging Face](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi05_base)                                             |
-| PI05_libero               | 3B     | [🤗 Hugging Face](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi05_libero)                                           |
-| PI05 RoboCasa（全データ） | 3B     | [🤗 Hugging Face](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi05_paligemma_robocasa_full_data_full_finetune_bs256) |
-| SmolVLA                   | 450M   | [🤗 Hugging Face](https://huggingface.co/lerobot/smolvla_base)                                                                       |
+| モデル                   | サイズ | ダウンロードリンク                                                                                                                  |
+| ------------------------ | ------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| GR00T N1.5               | 3B     | [🤗 Hugging Face](https://huggingface.co/nvidia/GR00T-N1.5-3B/tree/main)                                                            |
+| OpenVLA                  | 7B     | [🤗 Hugging Face](https://huggingface.co/openvla/openvla-7b)                                                                        |
+| FastWAM_base             | 5B     | [🤗 Hugging Face](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/fastwam_base)                                         |
+| Cosmos-Predict2.5-2B     | 2B     | [🤗 Hugging Face](https://huggingface.co/nvidia/Cosmos-Predict2.5-2B)                                                               |
+| PI0_base                 | 3B     | [🤗 Hugging Face](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi0_base)                                             |
+| PI0 RoboCasa（全データ） | 3B     | [🤗 Hugging Face](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi0_paligemma_robocasa_full_data_full_finetune_bs256) |
+| PI05_base                | 3B     | [🤗 Hugging Face](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi05_base)                                            |
+| PI05_libero              | 3B     | [🤗 Hugging Face](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi05_libero)                                          |
+| SmolVLA                  | 450M   | [🤗 Hugging Face](https://huggingface.co/lerobot/smolvla_base)                                                                      |
 
-各 config が期待するディレクトリ構成を維持したまま PI0 と PI0.5 の RoboCasa full-data checkpoint をダウンロードします：
+config が期待するディレクトリ構成を維持したまま PI0 の RoboCasa full-data checkpoint をダウンロードします：
 
 ```bash
 hf download limxdynamics/FluxVLAEngine \
   --include "pi0_paligemma_robocasa_full_data_full_finetune_bs256/*" \
-  --include "pi05_paligemma_robocasa_full_data_full_finetune_bs256/*" \
   --local-dir ./checkpoints
 ```
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -59,6 +59,8 @@ FluxVLA Engine是面向具身智能落地应用的全链路一体化工程平台
 
 ## 📢 最新动态
 
+**\[2026/08/25\]** 🔥 现已支持 FluxVLA-native DiT4DiT，包含 LIBERO 与 RoboCasa 的训练和推理流程。
+
 **\[2026/08/20\]** 🔥 现已支持 FluxVLA-native Cosmos3 Nano、Super 与 Edge，包括后训练和推理流程。
 
 **\[2026/08/13\]** 🔥 现已支持世界动作模型 FastWAM。
@@ -731,25 +733,23 @@ huggingface-cli download limxdynamics/FluxVLAData --repo-type dataset --include 
 <details>
 <summary><b>VLA 模型</b></summary>
 
-| 模型                      | 大小 | 下载链接                                                                                                                             |
-| ------------------------- | ---- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| GR00T N1.5                | 3B   | [🤗 Hugging Face](https://huggingface.co/nvidia/GR00T-N1.5-3B/tree/main)                                                             |
-| OpenVLA                   | 7B   | [🤗 Hugging Face](https://huggingface.co/openvla/openvla-7b)                                                                         |
-| FastWAM_base              | 5B   | [🤗 Hugging Face](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/fastwam_base)                                          |
-| Cosmos-Predict2.5-2B      | 2B   | [🤗 Hugging Face](https://huggingface.co/nvidia/Cosmos-Predict2.5-2B)                                                                |
-| PI0_base                  | 3B   | [🤗 Hugging Face](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi0_base)                                              |
-| PI0 RoboCasa（全量数据）  | 3B   | [🤗 Hugging Face](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi0_paligemma_robocasa_full_data_full_finetune_bs256)  |
-| PI05_base                 | 3B   | [🤗 Hugging Face](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi05_base)                                             |
-| PI05_libero               | 3B   | [🤗 Hugging Face](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi05_libero)                                           |
-| PI05 RoboCasa（全量数据） | 3B   | [🤗 Hugging Face](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi05_paligemma_robocasa_full_data_full_finetune_bs256) |
-| SmolVLA                   | 450M | [🤗 Hugging Face](https://huggingface.co/lerobot/smolvla_base)                                                                       |
+| 模型                     | 大小 | 下载链接                                                                                                                            |
+| ------------------------ | ---- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| GR00T N1.5               | 3B   | [🤗 Hugging Face](https://huggingface.co/nvidia/GR00T-N1.5-3B/tree/main)                                                            |
+| OpenVLA                  | 7B   | [🤗 Hugging Face](https://huggingface.co/openvla/openvla-7b)                                                                        |
+| FastWAM_base             | 5B   | [🤗 Hugging Face](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/fastwam_base)                                         |
+| Cosmos-Predict2.5-2B     | 2B   | [🤗 Hugging Face](https://huggingface.co/nvidia/Cosmos-Predict2.5-2B)                                                               |
+| PI0_base                 | 3B   | [🤗 Hugging Face](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi0_base)                                             |
+| PI0 RoboCasa（全量数据） | 3B   | [🤗 Hugging Face](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi0_paligemma_robocasa_full_data_full_finetune_bs256) |
+| PI05_base                | 3B   | [🤗 Hugging Face](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi05_base)                                            |
+| PI05_libero              | 3B   | [🤗 Hugging Face](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi05_libero)                                          |
+| SmolVLA                  | 450M | [🤗 Hugging Face](https://huggingface.co/lerobot/smolvla_base)                                                                      |
 
-按各自 config 预期的目录结构下载 PI0 和 PI0.5 RoboCasa 全量数据 checkpoint：
+按 config 预期的目录结构下载 PI0 RoboCasa 全量数据 checkpoint：
 
 ```bash
 hf download limxdynamics/FluxVLAEngine \
   --include "pi0_paligemma_robocasa_full_data_full_finetune_bs256/*" \
-  --include "pi05_paligemma_robocasa_full_data_full_finetune_bs256/*" \
   --local-dir ./checkpoints
 ```
 


### PR DESCRIPTION
## Summary

- Add the DiT4DiT release news dated August 25, 2026, matching its merge date.
- Remove the PI0.5 RoboCasa full-data checkpoint from checkpoint preparation because the training config initializes from `PI05_base`.
- Remove the corresponding PI0.5 checkpoint download command.
- Keep the English, Chinese, and Japanese READMEs consistent.

## Validation

- `git diff --check`