### PR TITLE
[Enhance]: Update dit4dit robocasa

### DIFF
--- a/configs/dit4dit/dit4dit_robocasa_full_data_full_finetune.py
+++ b/configs/dit4dit/dit4dit_robocasa_full_data_full_finetune.py
@@ -42,12 +42,12 @@ _frame_window_size = 9
 _image_frame_stride = 2
 _image_size = 224
 
-_ROBOCASA_STATISTIC_NAME = 'robocasa_gr1_24tasks_30ep'
+# Keep the statistics key aligned with the released DiT4DiT checkpoint. The
+# values themselves are aggregated from all 1,000 episodes of every task by
+# the dataset wrapper below.
+_ROBOCASA_STATISTIC_NAME = 'gr1'
 _ROBOCASA_DATA_ROOT = os.environ.get('ROBOCASA_DATA_ROOT',
                                      './datasets/robocasa_lerobot_V2.1')
-_OFFICIAL_GR1_STATS_PATH = os.environ.get(
-    'ROBOCASA_STATS_PATH', './datasets/robocasa_gr1_24tasks_first30ep/'
-    'official_groot_gr1_dataset_statistics.json')
 _ROBOCASA_TASK_PREFIX = 'gr1_unified'
 _ROBOCASA_ENV_SUFFIX = '_GR1ArmsAndWaistFourierHands_Env'
 
@@ -114,9 +114,11 @@ model = dict(
         conditional_frame_timestep=0.0001,
         future_loss_type='flow_matching',
         detach_hidden_states=True,
-        flow_matching_time_distribution='logit_normal',
-        flow_matching_high_sigma_ratio=0.05,
-        flow_matching_high_sigma_min=0.98,
+        # Match the released RoboCasa checkpoint rather than the YAML
+        # defaults: the official launch command overrides these three fields.
+        flow_matching_time_distribution='uniform',
+        flow_matching_high_sigma_ratio=None,
+        flow_matching_high_sigma_min=None,
         fsdp_min_num_params=0,
     ),
     vla_head=dict(
@@ -215,6 +217,9 @@ _dit4dit_train_transforms = [
         normalize_states=False,
         clip_norm=False,
         normalization_epsilon=0.0,
+        # Official GR00T normalization maps a constant action dimension to 0.
+        # The full 24-task statistics contain one such hand dimension.
+        zero_constant_min_max_dims=True,
         preserve_input_dtype=True,
         valid_action_dim=_ori_action_dim,
         mark_all_action_steps_valid=True,
@@ -235,7 +240,8 @@ _dit4dit_parquet_dataset = dict(
 )
 
 train_dataloader = dict(
-    # 32 GPUs * 8 samples/GPU = the source global batch of 256.
+    # The released recipe uses 16 GPUs * 4 samples/GPU. The common 8-GPU
+    # FluxVLA launch uses 8 samples/GPU for the same global batch of 64.
     per_device_batch_size=8,
     per_device_num_workers=4,
     dataset=dict(
@@ -246,7 +252,9 @@ train_dataloader = dict(
         },
         statistic_keys=['observation.state', 'timestamp', 'action'],
         statistic_name=_ROBOCASA_STATISTIC_NAME,
-        dataset_statistics_path=_OFFICIAL_GR1_STATS_PATH,
+        # Do not use the legacy first-30-episode statistics with this
+        # full-data recipe. The wrapper merges all 24 converted datasets and
+        # saves the resulting statistics next to the checkpoint.
         # Keep the full-data recipe's 24 tasks as equal-probability sources.
         datasets=[
             dict(
@@ -264,12 +272,13 @@ train_dataloader = dict(
 runner = dict(
     type='FSDPTrainRunner',
     max_epochs=None,
-    max_steps=100000,
+    max_steps=200000,
     grad_accumulation_steps=1,
     optimizer=dict(
         type='AdamW',
-        lr=1e-5,
+        lr=3e-5,
         weight_decay=1e-8,
+        weight_decay_all_params=True,
         eps=1e-8,
         betas=(0.9, 0.95),
         paramwise_learning_rate={
@@ -278,7 +287,7 @@ runner = dict(
         },
     ),
     max_grad_norm=1.0,
-    save_iter_interval=5000,
+    save_iter_interval=100000,
     max_keep_ckpts=10,
     collator=dict(
         type='DictCollator',
@@ -336,7 +345,6 @@ eval = dict(
     num_trials_per_task=50,
     seed=eval_seed,
     unnorm_key=_ROBOCASA_STATISTIC_NAME,
-    norm_stats_path=_OFFICIAL_GR1_STATS_PATH,
     action_order='n15',
     enable_mixed_precision_training=True,
     mixed_precision_dtype='bf16',
@@ -347,11 +355,9 @@ eval = dict(
             dict(
                 type='ProcessRobocasaEvalInputs',
                 img_key='video.ego_view_bg_crop_pad_res256_freq20',
-                # Convert the source 256x256 frame to float CHW / 255, but
-                # preserve its spatial size until the torch resize below.
+                # Keep uint8 pixels until the official cv2 INTER_AREA resize.
                 resize_size=256,
-                normalize=True,
-                value_range='unit',
+                normalize=False,
             ),
             dict(type='RobocasaGR1N15Bridge', expand_state_axis=0),
             dict(
@@ -365,8 +371,16 @@ eval = dict(
                 key='pixel_values',
                 height=_image_size,
                 width=_image_size,
-                backend='torch',
+                backend='cv2',
+                interpolation='area',
                 output_layout='nchw',
+            ),
+            # Match Cosmos VideoProcessor: uint8 [0, 255] -> [-1, 1].
+            dict(
+                type='SimpleNormalizeImages',
+                key='pixel_values',
+                preserve_leading_dims=True,
+                output_type='torch',
             ),
             dict(
                 type='PrepareVideo',
@@ -388,7 +402,9 @@ eval = dict(
         type='DenormalizeRobocasaAction',
         norm_type='min_max',
         action_dim=_ori_action_dim,
-        clip_actions=False,
+        # The official RoboCasa policy clips diffusion outputs before
+        # applying min/max denormalization.
+        clip_actions=True,
         # Reorder the stored FluxVLA statistics to the N1.5/DiT4DiT output
         # order before denormalization.
         stats_order='fluxvla',

--- a/configs/dit4dit/dit4dit_robocasa_full_data_full_finetune.py
+++ b/configs/dit4dit/dit4dit_robocasa_full_data_full_finetune.py
@@ -92,6 +92,12 @@ def _robocasa_task_env(task_name):
 
 model = dict(
     type='DiT4DiTVLA',
+    # Also allows evaluation of the released source checkpoint. Native
+    # FluxVLA checkpoints are detected by the runner and remain unchanged.
+    name_mapping=dict(
+        vlm_backbone='backbone_interface.extractor',
+        vla_head='action_model',
+    ),
     # Train from the Cosmos base model rather than a released DiT4DiT policy
     # checkpoint. Training resume is handled by the runner.
     # The source trainer repeats each sample four times with independently
@@ -109,7 +115,10 @@ model = dict(
         split_future_frames=True,
         # video_delta_indices=0..16 with action_video_freq_ratio=2.
         num_frames_out=_frame_window_size,
-        fixed_seed=42,
+        # The source wrapper's local ``fixed_seed = 42`` variable is never
+        # passed to its extractor. Official training therefore samples fresh
+        # VAE latents and initial diffusion noise on every forward.
+        fixed_seed=None,
         num_inference_steps=1,
         conditional_frame_timestep=0.0001,
         future_loss_type='flow_matching',
@@ -237,13 +246,20 @@ _dit4dit_parquet_dataset = dict(
     window_start_idx=0,
     frame_window_size=_frame_window_size,
     frame_sample_stride=_image_frame_stride,
+    # Official GR00T normalization operates on the parquet values in their
+    # inferred FP64 dtype and casts only the normalized result to FP16.
+    action_dtype=None,
 )
 
 train_dataloader = dict(
     # The released recipe uses 16 GPUs * 4 samples/GPU. The common 8-GPU
     # FluxVLA launch uses 8 samples/GPU for the same global batch of 64.
     per_device_batch_size=8,
-    per_device_num_workers=4,
+    # This is an IterableDataset that shards by both rank and worker. With
+    # four workers, one optimizer step consumes every fourth source batch
+    # instead of the source DataLoader's contiguous 64 indices. One worker
+    # preserves the official global batch sequence while still prefetching.
+    per_device_num_workers=1,
     dataset=dict(
         type='DistributedBalancedRepeatingDataset',
         name_mappings={
@@ -264,7 +280,11 @@ train_dataloader = dict(
         ],
         sampling_weights=[1.0] * len(_ROBOCASA_TASK_DIRS),
         shuffle=False,
-        reshuffle_each_epoch=True,
+        # The source DataLoader iterates indices without ``shuffle=True`` and
+        # its reset helper updates only ``dataloader.sampler``. It never calls
+        # ``LeRobotMixtureDataset.set_epoch()``, so the mixture keeps epoch 0
+        # and repeats the same deterministic index-to-sample mapping.
+        reshuffle_each_epoch=False,
         seed=seed,
     ),
 )
@@ -344,8 +364,15 @@ eval = dict(
     max_episode_steps=720,
     num_trials_per_task=50,
     seed=eval_seed,
+    # The released batch evaluator never seeds gym resets or diffusion action
+    # sampling. Keep both stochastic here so the reported score follows the
+    # same rollout distribution rather than a FluxVLA-specific fixed suite.
+    deterministic_env=False,
+    deterministic_action_sampling=False,
     unnorm_key=_ROBOCASA_STATISTIC_NAME,
     action_order='n15',
+    # The source wrapper always runs Cosmos under BF16 autocast. Its
+    # ``--use_bf16`` switch controls parameter casting, not this autocast.
     enable_mixed_precision_training=True,
     mixed_precision_dtype='bf16',
     dataset=dict(
@@ -394,7 +421,11 @@ eval = dict(
                 state_norm_type='none',
                 norm_type='min_max',
                 normalize_states=False,
-                output_dtype='float16',
+                # The source evaluator computes sin/cos from the environment's
+                # FP32 joint state and keeps it in FP32 until ``predict_action``
+                # casts it directly to the Cosmos hidden-state dtype. Avoid an
+                # intermediate FP16 round-trip in live rollouts.
+                output_dtype='float32',
             ),
         ],
     ),
@@ -405,9 +436,10 @@ eval = dict(
         # The official RoboCasa policy clips diffusion outputs before
         # applying min/max denormalization.
         clip_actions=True,
-        # Reorder the stored FluxVLA statistics to the N1.5/DiT4DiT output
-        # order before denormalization.
-        stats_order='fluxvla',
+        # Released source checkpoints store N1.5-order statistics, whereas
+        # FluxVLA checkpoints save the converted dataset's flat order. The
+        # runner resolves this from the checkpoint key convention.
+        stats_order='checkpoint',
     ),
 )
 
@@ -433,7 +465,7 @@ themis = dict(
             type='RoboCasaEnvironment',
             task_list=eval['task_list'],
             action_order=eval['action_order'],
-            deterministic_env=True,
+            deterministic_env=False,
             prompt_key='annotation.human.coarse_action',
             render_key='video.ego_view_pad_res256_freq20',
         ),

--- a/configs/dit4dit/dit4dit_robocasa_full_data_full_finetune.py
+++ b/configs/dit4dit/dit4dit_robocasa_full_data_full_finetune.py
@@ -421,10 +421,11 @@ eval = dict(
                 state_norm_type='none',
                 norm_type='min_max',
                 normalize_states=False,
-                # The source evaluator computes sin/cos from the environment's
-                # FP32 joint state and keeps it in FP32 until ``predict_action``
-                # casts it directly to the Cosmos hidden-state dtype. Avoid an
-                # intermediate FP16 round-trip in live rollouts.
+                # The source evaluator computes sin/cos from the
+                # environment's FP32 joint state and keeps it in FP32 until
+                # ``predict_action`` casts it directly to the Cosmos hidden
+                # state dtype. Avoid an intermediate FP16 round-trip in live
+                # rollouts.
                 output_dtype='float32',
             ),
         ],
@@ -436,10 +437,11 @@ eval = dict(
         # The official RoboCasa policy clips diffusion outputs before
         # applying min/max denormalization.
         clip_actions=True,
-        # Released source checkpoints store N1.5-order statistics, whereas
-        # FluxVLA checkpoints save the converted dataset's flat order. The
-        # runner resolves this from the checkpoint key convention.
-        stats_order='checkpoint',
+        # FluxVLA training checkpoints save action statistics in the
+        # converted dataset order; reorder them to the N1.5 action layout.
+        # When evaluating the released source checkpoint, override this with
+        # ``eval.denormalize_action.stats_order=native``.
+        stats_order='fluxvla',
     ),
 )
 

--- a/fluxvla/datasets/parquet_dataset.py
+++ b/fluxvla/datasets/parquet_dataset.py
@@ -62,6 +62,7 @@ class ParquetDataset(Dataset):
                  repeat_to_full_length: bool = False,
                  expose_index: bool = False,
                  supervise_terminal_padding: bool = False,
+                 action_dtype: Optional[str] = 'float32',
                  expected_dataset_version: Optional[str] = None) -> None:
         """Initialize the Parquet dataset.
 
@@ -114,6 +115,10 @@ class ParquetDataset(Dataset):
                 used to pad a window past the episode boundary remain valid in
                 the loss mask. OpenPI/LeRobot supervises these repeated hold
                 actions. Defaults to False for backward compatibility.
+            action_dtype (str, optional): NumPy dtype applied while assembling
+                action windows. Set to None to preserve the source values'
+                inferred dtype until downstream normalization. Defaults to
+                ``'float32'`` for backward compatibility.
             expected_dataset_version (str, optional): Expected FluxVLA dataset
                 content version. If omitted, no version check is performed so
                 existing local datasets remain usable.
@@ -122,6 +127,8 @@ class ParquetDataset(Dataset):
         if not 0 < train_episode_fraction <= 1:
             raise ValueError('train_episode_fraction must be in (0, 1].')
         self.action_window_size = action_window_size
+        self.action_dtype = (None if action_dtype is None else
+                             np.dtype(action_dtype))
         if isinstance(data_root_path, str):
             data_root_path = [data_root_path]
         self.data_root_path = data_root_path
@@ -352,6 +359,10 @@ class ParquetDataset(Dataset):
                 == self.dataset[index]['episode_index']
                 and self._get_dataset_index(index) == dataset_idx)
 
+    def _stack_actions(self, actions) -> np.ndarray:
+        """Assemble an action window using the configured source dtype."""
+        return np.array(actions, dtype=self.action_dtype)
+
     def __getitem__(self, index, dataset_statistics):
         index = self._resolve_index(index)
         data = self.dataset[index]
@@ -418,7 +429,7 @@ class ParquetDataset(Dataset):
 
         data['info'] = self.info[dataset_idx]
         data['stats'] = dataset_statistics[self.statistic_name]
-        data['actions'] = np.array(actions, dtype=np.float32)
+        data['actions'] = self._stack_actions(actions)
         data['action_masks'] = np.array(action_masks, dtype=np.float32)
         if self.expose_index:
             data['index'] = np.array(index, dtype=np.int64)

--- a/fluxvla/models/backbones/vlms/cosmos25.py
+++ b/fluxvla/models/backbones/vlms/cosmos25.py
@@ -16,6 +16,7 @@
 # DiT4DiT/model/modules/vlm/Cosmos25.py
 
 from __future__ import annotations
+from contextlib import contextmanager
 from typing import Any, Optional, Sequence, Type, Union
 
 import torch
@@ -74,6 +75,8 @@ class Cosmos25Backbone(nn.Module):
         num_frames_out: Optional default output video length. DiT4DiT uses the
             training video length even for single-frame eval inputs.
         fixed_seed: Optional deterministic noise seed for latent extraction.
+            Defaults to ``None`` so training samples fresh VAE latents and
+            initial diffusion noise on every forward, matching DiT4DiT.
         fsdp_min_num_params: Auto-wrap large non-block Cosmos modules above
             this parameter count when building an FSDP policy.
     """
@@ -91,7 +94,7 @@ class Cosmos25Backbone(nn.Module):
         frozen_submodules: Optional[Sequence[str]] = None,
         split_future_frames: bool = True,
         num_frames_out: Optional[int] = None,
-        fixed_seed: Optional[int] = 42,
+        fixed_seed: Optional[int] = None,
         num_inference_steps: int = 1,
         conditional_frame_timestep: float = 0.001,
         future_loss_type: Optional[str] = None,
@@ -249,13 +252,17 @@ class Cosmos25Backbone(nn.Module):
             **common_kwargs,
         )
 
-        with init_empty_weights():
-            transformer = CosmosTransformer3DModel.from_config(
-                transformer_config).to(dtype=self.torch_dtype)
-            vae = AutoencoderKLWan.from_config(vae_config).to(
-                dtype=self.torch_dtype)
-            text_encoder = Qwen2_5_VLForConditionalGeneration(text_config).to(
-                dtype=self.torch_dtype)
+        # Match ``from_pretrained(..., torch_dtype=...)`` by constructing
+        # parameters in the target dtype rather than calling ``module.to``.
+        # The latter also casts non-persistent rotary-frequency buffers to
+        # BF16. Since checkpoints do not contain those buffers, that changes
+        # every language embedding after architecture-only checkpoint load.
+        with self._temporary_default_dtype(self.torch_dtype):
+            with init_empty_weights():
+                transformer = CosmosTransformer3DModel.from_config(
+                    transformer_config)
+                vae = AutoencoderKLWan.from_config(vae_config)
+                text_encoder = Qwen2_5_VLForConditionalGeneration(text_config)
 
         return pipeline_cls(
             text_encoder=text_encoder,
@@ -265,6 +272,17 @@ class Cosmos25Backbone(nn.Module):
             scheduler=scheduler,
             safety_checker=safety_checker,
         )
+
+    @staticmethod
+    @contextmanager
+    def _temporary_default_dtype(dtype: torch.dtype):
+        """Construct low-precision parameters without casting FP32 buffers."""
+        previous = torch.get_default_dtype()
+        torch.set_default_dtype(dtype)
+        try:
+            yield
+        finally:
+            torch.set_default_dtype(previous)
 
     @property
     def device(self) -> torch.device:
@@ -537,9 +555,14 @@ class Cosmos25Backbone(nn.Module):
                                   Sequence[torch.Generator]]] = None,
     ) -> torch.Tensor:
         vae_dtype = getattr(self.vae, 'dtype', self.dtype)
-        video = video_bcthw.to(device=self.device, dtype=vae_dtype)
+        # The source path runs VideoProcessor normalization while pixels are
+        # still FP32, then casts the normalized video to the VAE dtype. Doing
+        # the affine transform after a BF16 cast changes the condition latent
+        # and is strongly amplified by the Cosmos transformer.
+        video = video_bcthw.to(device=self.device)
         if video.min() >= 0.0:
             video = video * 2.0 - 1.0
+        video = video.to(dtype=vae_dtype)
         if video.shape[2] < num_frames_out:
             pad = video.new_zeros(video.shape[0], video.shape[1],
                                   num_frames_out - video.shape[2],
@@ -713,6 +736,16 @@ class Cosmos25Backbone(nn.Module):
             t = torch.where(high_mask, high_t, t)
         return t
 
+    @staticmethod
+    def _mix_condition_timestep(
+        cond_indicator: torch.Tensor,
+        cond_timestep: torch.Tensor,
+        generated_timestep: torch.Tensor,
+    ) -> torch.Tensor:
+        """Blend condition/future timesteps with source dtype promotion."""
+        return (cond_indicator * cond_timestep +
+                (1.0 - cond_indicator) * generated_timestep)
+
     def _future_video_flow_matching_loss(
         self,
         condition_video: torch.Tensor,
@@ -773,13 +806,14 @@ class Cosmos25Backbone(nn.Module):
         t_b1t11[:, :, cond_count:cond_count + time_steps] = t
         t_b1t11 = t_b1t11.to(dtype=transformer_dtype)
 
+        # Keep the same mixed-input promotion order as the source. In
+        # particular, ``cond_latents`` and ``cond_indicator`` remain FP32
+        # here; pre-casting them to BF16 changes the Cosmos FM gradients.
         in_latents = (
-            cond_mask_t * cond_latents.to(transformer_dtype) +
+            cond_mask_t * cond_latents +
             (1.0 - cond_mask_t) * xt_full.to(transformer_dtype))
-        in_timestep = (
-            cond_indicator.to(transformer_dtype) *
-            cond_timestep.to(transformer_dtype) +
-            (1.0 - cond_indicator.to(transformer_dtype)) * t_b1t11)
+        in_timestep = self._mix_condition_timestep(cond_indicator,
+                                                   cond_timestep, t_b1t11)
 
         v_pred = self.transformer(
             hidden_states=in_latents,
@@ -931,9 +965,10 @@ class Cosmos25Backbone(nn.Module):
             in_latents = (
                 cond_mask_t * cond_latents.to(transformer_dtype) +
                 (1.0 - cond_mask_t) * latents.to(transformer_dtype))
-            in_timestep = cond_indicator.to(
-                transformer_dtype) * cond_timestep.to(transformer_dtype) + (
-                    1.0 - cond_indicator.to(transformer_dtype)) * sigma
+            # Source DiT4DiT keeps this interpolation in FP32 and passes the
+            # resulting timestep tensor to the BF16 Cosmos transformer.
+            in_timestep = self._mix_condition_timestep(cond_indicator,
+                                                       cond_timestep, sigma)
 
             # The selected feature is intentionally detached in the source
             # recipe. Do not build an autograd/checkpoint graph for this first

--- a/fluxvla/models/heads/dit4dit_action_head.py
+++ b/fluxvla/models/heads/dit4dit_action_head.py
@@ -262,9 +262,12 @@ class DiT4DiTActionHead(nn.Module):
                              'actions, and action masks.')
         device = vl_embs.device
         actions = actions.to(device=device, dtype=vl_embs.dtype)
-        action_mask = action_mask.to(device=device, dtype=vl_embs.dtype)
+        action_mask = action_mask.to(device=device, dtype=torch.bool)
 
-        noise = torch.randn_like(actions)
+        # Use the same factory call as the source implementation so a shared
+        # RNG state produces the same flow-matching noise tensor.
+        noise = torch.randn(
+            actions.shape, device=actions.device, dtype=actions.dtype)
         t = self.sample_time(
             actions.shape[0], device=actions.device, dtype=actions.dtype)
         t = t[:, None, None]
@@ -292,9 +295,11 @@ class DiT4DiTActionHead(nn.Module):
         )
         pred = self.action_decoder(model_output)
         pred_actions = pred[:, -actions.shape[1]:]
-        loss = ((pred_actions.float() - velocity.float())**2 *
-                action_mask.float())
-        return loss.sum() / action_mask.float().sum().clamp_min(1.0)
+        # Preserve the released DiT4DiT expression and its native promotion
+        # rules. Depending on the DiT output dtype this can reduce in FP32 or
+        # BF16; do not force a different dtype here.
+        loss = ((pred_actions - velocity)**2) * action_mask
+        return loss.sum() / action_mask.sum()
 
     @torch.no_grad()
     def predict_action(self,

--- a/fluxvla/models/vlas/dit4dit_vla.py
+++ b/fluxvla/models/vlas/dit4dit_vla.py
@@ -249,8 +249,10 @@ class DiT4DiTVLA(BaseVLA):
         attention_mask = backbone_outputs.attention_mask
         actions = actions.to(
             device=last_hidden.device, dtype=last_hidden.dtype)
-        action_masks = action_masks.to(
-            device=last_hidden.device, dtype=last_hidden.dtype)
+        # Keep the validity mask discrete. The source DiT4DiT collator passes
+        # a bool mask into the action head rather than casting it with the
+        # floating-point model inputs.
+        action_masks = action_masks.to(device=last_hidden.device)
         if states is not None:
             states = states.to(
                 device=last_hidden.device, dtype=last_hidden.dtype)

--- a/fluxvla/transforms/normalize.py
+++ b/fluxvla/transforms/normalize.py
@@ -429,6 +429,10 @@ class NormalizeStatesAndActions:
             to [-1, 1]. Defaults to False.
         normalize_states (bool): Whether to normalize states before optional
             padding/truncation. Defaults to True.
+        zero_constant_min_max_dims (bool): If True, map dimensions whose
+            min/max statistics are identical to zero. This matches GR00T's
+            min-max transform and avoids division by zero. Defaults to False
+            to preserve existing normalization behavior.
         preserve_input_dtype (bool): Keep normalization arithmetic in the
             input array dtype even when ``output_dtype`` is configured.
         output_dtype (str | None): Optional NumPy dtype used for normalization
@@ -459,6 +463,7 @@ class NormalizeStatesAndActions:
                  normalization_epsilon: float = 1e-6,
                  preserve_input_dtype: bool = False,
                  normalize_states: bool = True,
+                 zero_constant_min_max_dims: bool = False,
                  discrete_action_dims: List[int] = None,
                  discrete_state_dims: List[int] = None,
                  discrete_norm_type: str = 'min_max',
@@ -482,6 +487,7 @@ class NormalizeStatesAndActions:
         self.normalization_epsilon = float(normalization_epsilon)
         self.preserve_input_dtype = bool(preserve_input_dtype)
         self.normalize_states = normalize_states
+        self.zero_constant_min_max_dims = bool(zero_constant_min_max_dims)
         self.output_dtype = (None if output_dtype is None else
                              np.dtype(output_dtype))
         if (self.output_dtype is not None
@@ -691,7 +697,14 @@ class NormalizeStatesAndActions:
         low = self._statistics_array(stats['min'], x)
         high = self._statistics_array(stats['max'], x)
         epsilon = self._typed_epsilon(x)
-        normalized = (x - low) / (high - low + epsilon) * 2.0 - 1.0
+        value_range = high - low
+        if self.zero_constant_min_max_dims:
+            valid_range = value_range != 0
+            safe_range = np.where(valid_range, value_range + epsilon, 1.0)
+            normalized = (x - low) / safe_range * 2.0 - 1.0
+            normalized = np.where(valid_range, normalized, 0.0)
+        else:
+            normalized = (x - low) / (value_range + epsilon) * 2.0 - 1.0
         if self.clip_norm:
             normalized = np.clip(normalized, -1, 1)
         return np.where(norm_mask, normalized, x)

--- a/fluxvla/transforms/normalize.py
+++ b/fluxvla/transforms/normalize.py
@@ -529,10 +529,14 @@ class NormalizeStatesAndActions:
             self.delta_action_dim_mask = None
 
     def __call__(self, data: Dict) -> Dict:
-        states = np.asarray(data['states'], dtype=np.float32)
+        states = (
+            np.asarray(data['states']) if self.preserve_input_dtype else
+            np.asarray(data['states'], dtype=np.float32))
         actions = None
         if self.action_key is not None and 'actions' in data:
-            actions = np.asarray(data['actions'], dtype=np.float32)
+            actions = (
+                np.asarray(data['actions']) if self.preserve_input_dtype else
+                np.asarray(data['actions'], dtype=np.float32))
             if (self.action_norm_mask is not None
                     and len(self.action_norm_mask) != actions.shape[-1]):
                 raise ValueError(


### PR DESCRIPTION
## Summary

Align the DiT4DiT RoboCasa full-data training and evaluation pipeline with the official recipe.

## Changes

- Correct full-data statistics, action normalization, dtype handling, and constant-dimension behavior.
- Align Cosmos2.5 preprocessing, noise sampling, flow-matching timesteps, and checkpoint initialization.
- Align DiT4DiT action masking and loss computation.
- Match the official training schedule and RoboCasa evaluation preprocessing.
- Fix native and official checkpoint loading and action-statistics ordering.
- Update RoboCasa results in the English, Chinese, and Japanese READMEs.

## RoboCasa Results

| Cabinet | Drawer | Microwave | Generalization | Average |
| ------- | ------ | --------- | -------------- | ------- |
| 63.00%  | 52.00% | 59.00%    | 57.00%         | 57.25%  |

Evaluated with 50 trials per task.

[Hugging Face checkpoint](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/dit4dit_robocasa_full_data_full_finetune_bs64)

## Compatibility

- Non-DiT4DiT configs retain their existing default behavior.
- Shared DiT4DiT backbone and action-head numerical alignment also applies to the existing DiT4DiT LIBERO config.

## Validation

- DiT4DiT model and transform tests: `11 passed`
- `git diff --check`