### PR TITLE
[Docs]: Update robocasa results

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,12 @@ FluxVLA Engine is a full-stack, end-to-end engineering platform for deploying em
 
 #### RoboCasa GR1
 
-| Model          | Training Data       | Cabinet | Drawer | Microwave | Generalization | Average                                                                                                                                 |
-| -------------- | ------------------- | ------- | ------ | --------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| FluxVLA(GR00T) | 24 tasks, 30 demos  | 22.7%   | 35.7%  | 32.5%     | 48.9%          | [44.3%(50trials)](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/gr00t_eagle_3b_robocasa_gr1_24x30_finetune_bs64)          |
-| FluxVLA(PI0)   | 24 tasks, full data | 60.00%  | 56.00% | 48.00%    | 49.33%         | [51.00% (50 trials)](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi0_paligemma_robocasa_full_data_full_finetune_bs256)  |
-| FluxVLA(PI0.5) | 24 tasks, full data | 60.00%  | 51.00% | 52.00%    | 50.44%         | [51.42% (50 trials)](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi05_paligemma_robocasa_full_data_full_finetune_bs256) |
+| Model            | Training Data       | Cabinet | Drawer | Microwave | Generalization | Average                                                                                                                                 |
+| ---------------- | ------------------- | ------- | ------ | --------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| FluxVLA(GR00T)   | 24 tasks, 30 demos  | 22.7%   | 35.7%  | 32.5%     | 48.9%          | [44.3%(50trials)](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/gr00t_eagle_3b_robocasa_gr1_24x30_finetune_bs64)          |
+| FluxVLA(PI0)     | 24 tasks, full data | 60.00%  | 56.00% | 48.00%    | 49.33%         | [51.00% (50 trials)](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi0_paligemma_robocasa_full_data_full_finetune_bs256)  |
+| FluxVLA(PI0.5)   | 24 tasks, full data | 60.00%  | 51.00% | 52.00%    | 50.44%         | [51.42% (50 trials)](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi05_paligemma_robocasa_full_data_full_finetune_bs256) |
+| FluxVLA(DiT4DiT) | 24 tasks, full data | 63.00%  | 52.00% | 59.00%    | 57.00%         | [57.25% (50 trials)](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/dit4dit_robocasa_full_data_full_finetune_bs64)         |
 
 #### Notes
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -45,11 +45,12 @@ FluxVLA Engine は、具現知能（Embodied Intelligence）の実運用を見�
 
 #### RoboCasa GR1
 
-| モデル         | 学習データ          | Cabinet | Drawer | Microwave | Generalization | Average                                                                                                                                         |
-| -------------- | ------------------- | ------- | ------ | --------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| FluxVLA(GR00T) | 24 タスク、30 デモ  | 22.7%   | 35.7%  | 32.5%     | 48.9%          | [44.3%(50trials)](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/gr00t_eagle_3b_robocasa_gr1_24x30_finetune_bs64)                  |
-| FluxVLA(PI0)   | 24 タスク、全データ | 60.00%  | 56.00% | 48.00%    | 49.33%         | [51.00%（各タスク 50 試行）](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi0_paligemma_robocasa_full_data_full_finetune_bs256)  |
-| FluxVLA(PI0.5) | 24 タスク、全データ | 60.00%  | 51.00% | 52.00%    | 50.44%         | [51.42%（各タスク 50 試行）](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi05_paligemma_robocasa_full_data_full_finetune_bs256) |
+| モデル           | 学習データ          | Cabinet | Drawer | Microwave | Generalization | Average                                                                                                                                         |
+| ---------------- | ------------------- | ------- | ------ | --------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| FluxVLA(GR00T)   | 24 タスク、30 デモ  | 22.7%   | 35.7%  | 32.5%     | 48.9%          | [44.3%(50trials)](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/gr00t_eagle_3b_robocasa_gr1_24x30_finetune_bs64)                  |
+| FluxVLA(PI0)     | 24 タスク、全データ | 60.00%  | 56.00% | 48.00%    | 49.33%         | [51.00%（各タスク 50 試行）](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi0_paligemma_robocasa_full_data_full_finetune_bs256)  |
+| FluxVLA(PI0.5)   | 24 タスク、全データ | 60.00%  | 51.00% | 52.00%    | 50.44%         | [51.42%（各タスク 50 試行）](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi05_paligemma_robocasa_full_data_full_finetune_bs256) |
+| FluxVLA(DiT4DiT) | 24 タスク、全データ | 63.00%  | 52.00% | 59.00%    | 57.00%         | [57.25%（各タスク 50 試行）](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/dit4dit_robocasa_full_data_full_finetune_bs64)         |
 
 #### 注記
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -45,11 +45,12 @@ FluxVLA Engine是面向具身智能落地应用的全链路一体化工程平台
 
 #### RoboCasa GR1
 
-| 模型           | 训练数据             | Cabinet | Drawer | Microwave | Generalization | Average                                                                                                                                         |
-| -------------- | -------------------- | ------- | ------ | --------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| FluxVLA(GR00T) | 24 个任务，30 条演示 | 22.7%   | 35.7%  | 32.5%     | 48.9%          | [44.3%(50trials)](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/gr00t_eagle_3b_robocasa_gr1_24x30_finetune_bs64)                  |
-| FluxVLA(PI0)   | 24 个任务，全量数据  | 60.00%  | 56.00% | 48.00%    | 49.33%         | [51.00%（每任务 50 次试验）](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi0_paligemma_robocasa_full_data_full_finetune_bs256)  |
-| FluxVLA(PI0.5) | 24 个任务，全量数据  | 60.00%  | 51.00% | 52.00%    | 50.44%         | [51.42%（每任务 50 次试验）](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi05_paligemma_robocasa_full_data_full_finetune_bs256) |
+| 模型             | 训练数据             | Cabinet | Drawer | Microwave | Generalization | Average                                                                                                                                         |
+| ---------------- | -------------------- | ------- | ------ | --------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| FluxVLA(GR00T)   | 24 个任务，30 条演示 | 22.7%   | 35.7%  | 32.5%     | 48.9%          | [44.3%(50trials)](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/gr00t_eagle_3b_robocasa_gr1_24x30_finetune_bs64)                  |
+| FluxVLA(PI0)     | 24 个任务，全量数据  | 60.00%  | 56.00% | 48.00%    | 49.33%         | [51.00%（每任务 50 次试验）](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi0_paligemma_robocasa_full_data_full_finetune_bs256)  |
+| FluxVLA(PI0.5)   | 24 个任务，全量数据  | 60.00%  | 51.00% | 52.00%    | 50.44%         | [51.42%（每任务 50 次试验）](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/pi05_paligemma_robocasa_full_data_full_finetune_bs256) |
+| FluxVLA(DiT4DiT) | 24 个任务，全量数据  | 63.00%  | 52.00% | 59.00%    | 57.00%         | [57.25%（每任务 50 次试验）](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/dit4dit_robocasa_full_data_full_finetune_bs64)         |
 
 #### 说明
 


### PR DESCRIPTION
## Summary

Update the RoboCasa benchmark tables with the DiT4DiT full-data evaluation results and released checkpoint.

## Changes

- Add DiT4DiT RoboCasa results to the English, Chinese, and Japanese READMEs.
- Report 63.00% Cabinet, 52.00% Drawer, 59.00% Microwave, 57.00% Generalization, and 57.25% average success rate.
- Link the released [Hugging Face checkpoint](https://huggingface.co/limxdynamics/FluxVLAEngine/tree/main/dit4dit_robocasa_full_data_full_finetune_bs64).
- Align the affected Markdown table formatting.

## Validation

- `git diff --check`
- Documentation-only change; no runtime or config behavior is modified.