### PR TITLE
[Feat] Add reBot dual-arm inference support

### DIFF
--- a/configs/pi05/pi05_rebot_dual_inference.py
+++ b/configs/pi05/pi05_rebot_dual_inference.py
@@ -1,0 +1,164 @@
+# Copyright 2026 Limx Dynamics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Standalone PI0.5 inference config for a dual-arm reBot."""
+
+_delta_mask = [True] * 6 + [False] + [True] * 6 + [False]
+
+inference_model = dict(
+    type='PI05FlowMatching',
+    llm_backbone=dict(
+        type='ConditionGemmaModel',
+        adarms_cond_dim=None,
+        attention_bias=False,
+        attention_dropout=0.0,
+        bos_token_id=2,
+        eos_token_id=1,
+        head_dim=256,
+        hidden_act='gelu_pytorch_tanh',
+        hidden_activation='gelu_pytorch_tanh',
+        hidden_size=2048,
+        initializer_range=0.02,
+        intermediate_size=16384,
+        max_position_embeddings=8192,
+        model_type='gemma',
+        num_attention_heads=8,
+        num_hidden_layers=18,
+        num_key_value_heads=1,
+        rms_norm_eps=1e-06,
+        rope_theta=10000.0,
+        torch_dtype='float32',
+        use_cache=True,
+        vocab_size=257152),
+    vision_backbone=dict(
+        type='SigLIPViTBackbone',
+        vision_backbone_id='siglip_224',
+        openpi_stem_fp32=True,
+        vision_config=dict(
+            attention_dropout=0.0,
+            hidden_act='gelu_pytorch_tanh',
+            hidden_size=1152,
+            image_size=224,
+            intermediate_size=4304,
+            layer_norm_eps=1e-06,
+            model_type='siglip_vision_model',
+            num_attention_heads=16,
+            num_channels=3,
+            num_hidden_layers=27,
+            patch_size=14,
+            projection_dim=2048,
+            projector_hidden_act='gelu_fast',
+            torch_dtype='float32',
+            vision_use_head=False)),
+    projector=dict(type='LinearProjector', in_dim=1152, out_dim=2048),
+    proj_width=1024,
+    n_action_steps=50,
+    action_in_proj=dict(type='LinearProjector', in_dim=32, out_dim=1024),
+    action_out_proj=dict(type='LinearProjector', in_dim=1024, out_dim=32),
+    time_mlp_in=dict(type='LinearProjector', in_dim=1024, out_dim=1024),
+    time_mlp_out=dict(type='LinearProjector', in_dim=1024, out_dim=1024),
+    time_sampler='beta',
+    time_beta_alpha=1.5,
+    time_beta_beta=1.0,
+    openpi_fp32_flow=True,
+    max_action_dim=32,
+    llm_expert=dict(
+        type='ConditionGemmaModel',
+        attention_bias=False,
+        adarms_cond_dim=1024,
+        attention_dropout=0.0,
+        bos_token_id=2,
+        eos_token_id=1,
+        head_dim=256,
+        hidden_act='gelu_pytorch_tanh',
+        hidden_activation='gelu_pytorch_tanh',
+        hidden_size=1024,
+        initializer_range=0.02,
+        intermediate_size=4096,
+        max_position_embeddings=8192,
+        model_type='gemma',
+        num_attention_heads=8,
+        num_hidden_layers=18,
+        num_key_value_heads=1,
+        pad_token_id=0,
+        rms_norm_eps=1e-06,
+        rope_theta=10000.0,
+        torch_dtype='float32',
+        transformers_version='4.48.1',
+        use_adarms=True,
+        use_cache=True,
+        vocab_size=257152),
+    freeze_llm_backbone=False,
+    freeze_vision_backbone=False,
+    pretrained_name_or_path=None,
+    ori_action_dim=14,
+    loss_action_dim=32)
+
+inference = dict(
+    type='RebotDualInferenceRunner',
+    seed=7,
+    keep_params_fp32=True,
+    enable_mixed_precision=True,
+    mixed_precision_dtype='bf16',
+    task_descriptions={'1': 'Complete the requested bimanual task.'},
+    task_suite_name='private',
+    state_dim=14,
+    dataset=dict(
+        type='PrivateInferenceDataset',
+        img_keys=['cam_front', 'cam_wrist_left', 'cam_wrist_right'],
+        transforms=[
+            dict(
+                type='NormalizeStatesAndActions',
+                state_dim=32,
+                action_dim=32,
+                state_key='proprio',
+                action_key=None,
+                norm_type='quantile',
+                output_dtype='float32'),
+            dict(type='PreparePromptWithState'),
+            dict(
+                type='ProcessPrompts',
+                max_len=200,
+                tokenizer=dict(
+                    type='PretrainedTokenizer',
+                    model_path='checkpoints/pi05_base')),
+            dict(
+                type='ResizeImagesWithPad',
+                height=224,
+                width=224,
+                backend='pil'),
+            dict(type='SimpleNormalizeImages'),
+        ]),
+    denormalize_action=dict(
+        type='DenormalizeDeltaAction',
+        norm_type='quantile',
+        action_dim=14,
+        delta_action_mask=_delta_mask),
+    action_chunk=10,
+    publish_rate=30,
+    max_publish_step=10000,
+    use_robot_base=False,
+    disable_puppet_arm=False,
+    operator=dict(
+        type='RebotDualOperator',
+        image_encoding='rgb8',
+        img_front_topic='/camera_front/color/image_raw',
+        img_left_topic='/camera_left_wrist/color/image_raw',
+        img_right_topic='/camera_right_wrist/color/image_raw',
+        puppet_arm_left_topic='/left_arm/joint_states',
+        puppet_arm_right_topic='/right_arm/joint_states',
+        puppet_arm_left_cmd_topic=(
+            '/left_arm/rebot_joint_controller/target_joint_state'),
+        puppet_arm_right_cmd_topic=(
+            '/right_arm/rebot_joint_controller/target_joint_state'),
+        publish_rate=30))

--- a/docs/reBot.md
+++ b/docs/reBot.md
@@ -1,0 +1,259 @@
+# reBot Bimanual Real-Robot Deployment Guide
+
+This guide defines the FluxVLA deployment contract for two reBot 102 leader
+arms, two B601-DM follower arms, one front RealSense D455, and two wrist
+RealSense D405 cameras. It covers the LeRobot v3 data contract and PI0.5
+real-robot inference over ROS1.
+
+______________________________________________________________________
+
+## Table of Contents
+
+1. [System Requirements](#1-system-requirements)
+2. [Workspace Setup](#2-workspace-setup)
+3. [Hardware Mapping](#3-hardware-mapping)
+4. [LeRobot Data Contract](#4-lerobot-data-contract)
+5. [Data Collection](#5-data-collection)
+6. [Validation and Upload](#6-validation-and-upload)
+7. [FluxVLA Inference](#7-fluxvla-inference)
+8. [Safety](#8-safety)
+
+______________________________________________________________________
+
+## 1. System Requirements
+
+- Ubuntu 20.04
+- ROS1 Noetic
+- Conda environment: `~/miniconda3/envs/lerobot_bimanual`
+- Two reBot 102 leader arms
+- Two reBot B601-DM follower arms
+- Intel RealSense D455 front camera and two D405 wrist cameras
+- Stable `/dev/rebot_*` links for all four arm serial devices
+
+Unlike the Franka workflow, reBot collection writes LeRobot v3 directly. ROS
+Parquet collection and a separate conversion pass are not required.
+
+## 2. Workspace Setup
+
+```bash
+cd ~/reBot/rebot_ros1_ws
+source /opt/ros/noetic/setup.bash
+catkin_make
+source devel/setup.bash
+```
+
+Each new terminal must source ROS and the workspace:
+
+```bash
+source /opt/ros/noetic/setup.bash
+source ~/reBot/rebot_ros1_ws/devel/setup.bash
+```
+
+## 3. Hardware Mapping
+
+Arm serial devices:
+
+```text
+/dev/rebot_follower_left
+/dev/rebot_follower_right
+/dev/rebot_leader_left
+/dev/rebot_leader_right
+```
+
+Camera mapping:
+
+```text
+cam_front        D455  <FRONT_CAMERA_SERIAL>
+cam_wrist_left   D405  <LEFT_WRIST_CAMERA_SERIAL>
+cam_wrist_right  D405  <RIGHT_WRIST_CAMERA_SERIAL>
+```
+
+Validate all devices before collection:
+
+```bash
+rosrun rebot_bimanual_ros rebot-check-devices --active
+```
+
+## 4. LeRobot Data Contract
+
+Each frame contains:
+
+```text
+observation.state                    float32[14]
+action                               float32[14]
+observation.images.cam_front         video[480,640,3]
+observation.images.cam_wrist_left    video[480,640,3]
+observation.images.cam_wrist_right   video[480,640,3]
+timestamp                            float32[1]
+frame_index                          int64[1]
+episode_index                        int64[1]
+index                                int64[1]
+task_index                           int64[1]
+```
+
+State, action, timestamps, and indices are stored in `data/**/*.parquet`.
+Images are AV1 MP4 streams under `videos/`, and task text is indexed through
+`meta/tasks.parquet`.
+
+State and action values follow the ROS `JointState` convention and are recorded
+in radians in this order:
+
+```text
+left_shoulder_pan.pos
+left_shoulder_lift.pos
+left_elbow_flex.pos
+left_wrist_flex.pos
+left_wrist_yaw.pos
+left_wrist_roll.pos
+left_gripper.pos
+right_shoulder_pan.pos
+right_shoulder_lift.pos
+right_elbow_flex.pos
+right_wrist_flex.pos
+right_wrist_yaw.pos
+right_wrist_roll.pos
+right_gripper.pos
+```
+
+This 14-D contract is embodiment-specific. It intentionally does not pad reBot
+to Franka's 16-D dual-arm state.
+
+## 5. Data Collection
+
+```bash
+roslaunch rebot_bimanual_ros dual_arm.launch \
+  enable_leaders:=true \
+  enable_teleop:=true \
+  enable_cameras:=true \
+  enable_camera_preview:=true \
+  launch_data_collection:=true \
+  dataset_repo_id:=rebot_dual/20260811 \
+  task_description:="Pick up the object and place it in the box" \
+  data_frame_rate:=30 \
+  num_episodes:=0 \
+  auto_record_on_leader_motion:=true \
+  motion_start_threshold_rad:=0.20 \
+  home_stop_threshold_rad:=0.15 \
+  home_dwell_sec:=0.8 \
+  home_capture_sec:=1.0
+```
+
+The date can be used as the dataset name. A missing directory is created, while
+an existing directory is resumed automatically after FPS/schema validation.
+The default local root for the command above is:
+
+```text
+~/reBot/Data/lerobot/rebot_dual/20260811
+```
+
+The driver publishes follower states and leader states as `JointState`; ROS
+relays turn the leader streams into follower command topics. The recorder uses
+approximate timestamp synchronization for the two follower states and three
+images, then associates the latest command before each synchronized frame.
+
+At startup, hold both leaders at the desired reset pose until the recorder logs
+`Captured the dual-leader reset pose`. Recording starts when any of the twelve
+arm joints moves at least `0.20 rad` from reset. It saves when all twelve joints
+remain within `0.15 rad` for `0.8 s`, then rearms for the next episode. Gripper
+motion is excluded from boundary detection. Automatic arming is blocked until
+the camera and robot topics have produced a synchronized frame.
+
+To use the same manual topic contract as the Franka collector, set
+`auto_record_on_leader_motion:=false` and publish:
+
+```bash
+rostopic pub -1 /data_collection/record_cmd std_msgs/String "data: 'start'"
+rostopic pub -1 /data_collection/record_cmd std_msgs/String "data: 'stop'"
+rostopic pub -1 /data_collection/record_cmd std_msgs/String "data: 'cancel'"
+```
+
+`stop` saves and `cancel` discards the active episode. Neither command stops
+the driver or disables torque. Stopping the full launch disconnects the two
+followers and disables their torque.
+
+The three RealSense pipelines are opened sequentially by one Conda
+`pyrealsense2` process and retain the canonical ROS image topics. This avoids
+the USB-claim race seen with three concurrent ROS librealsense 2.50 nodelets.
+
+Datasets created by older wrappers may use `main`, `left_wrist`, and
+`right_wrist` camera keys. Do not resume those datasets with this canonical
+schema; start a new dataset ID instead.
+
+## 6. Validation and Upload
+
+Validate the local dataset before training or upload:
+
+```bash
+rosrun rebot_bimanual_ros rebot-dataset validate \
+  --repo-id rebot_dual/20260811
+```
+
+Upload the validated dataset to a remote server over SSH. Replace the port,
+user, host, and destination directory for the deployment environment:
+
+```bash
+rosrun rebot_bimanual_ros rebot-dataset upload \
+  --repo-id rebot_dual/20260811 \
+  --destination <REMOTE_USER>@<REMOTE_IP>:/path/to/RealRobot_rebot_dual_lerobotv3/ \
+  --ssh-port <SSH_PORT>
+```
+
+The command always validates the schema first, then runs `rsync` with archive,
+compression, progress, and partial-file preservation enabled. It copies the
+dataset directory itself into the remote base directory. Add `--dry-run` to
+check the source and destination without writing remote files. `rsync` must be
+installed on both the local and remote hosts; use `scp -r -P <SSH_PORT>` if the
+remote server cannot install it.
+
+## 7. FluxVLA Inference
+
+FluxVLA reads this output through `ParquetDatasetV3`, which supports LeRobot
+v3 metadata (`tasks.parquet`, `meta/episodes/*.parquet`, and `stats.json`). A
+reBot PI0.5 training recipe must preserve this contract:
+
+```text
+dataset type: ParquetDatasetV3
+state key: observation.state
+action key: action
+images: cam_front, cam_wrist_left, cam_wrist_right
+state/action dimension: 14 (padded internally to the model maximum)
+```
+
+The standalone inference config is
+`configs/pi05/pi05_rebot_dual_inference.py`. It does not inherit another
+robot config. Before launch, provide:
+
+```text
+checkpoints/pi05_base/                    tokenizer assets
+<run-directory>/
+  checkpoints/<checkpoint>.safetensors   fine-tuned model
+  dataset_statistics.json                transformed statistics
+```
+
+The statistics file follows the standard FluxVLA layout: `private.proprio`
+contains state statistics and `private.action` contains transformed action
+statistics. Joint actions are state-relative in dimensions 0-5 and 7-12;
+grippers in dimensions 6 and 13 remain absolute.
+
+Start the reBot ROS drivers and cameras, verify the configured topics, then
+run:
+
+```bash
+python scripts/inference_real_robot.py \
+  --config configs/pi05/pi05_rebot_dual_inference.py \
+  --ckpt-path <run-directory>/checkpoints/<checkpoint>.safetensors
+```
+
+`RebotDualOperator` receives three RGB streams and two 7-D joint states.
+`RebotDualInferenceRunner` uses the common FluxVLA operator and runner bases;
+it does not inherit ALOHA hardware behavior. Continuous reBot gripper angles
+remain part of each 7-D arm command. Configure and validate
+`inference.prepare_pose` before using task ID `0` for automatic reset.
+
+## 8. Safety
+
+- Support both followers before stopping collection.
+- Final disconnect disables follower torque; episode transitions do not.
+- Do not run calibration, teleoperation, and recording processes concurrently.
+- Validate stable serial mappings after moving USB connections.
+- Stop immediately if a leader stream stalls or a follower reports a CAN error.

--- a/fluxvla/engines/operators/__init__.py
+++ b/fluxvla/engines/operators/__init__.py
@@ -18,5 +18,6 @@ from .fluxbisim_aloha_operator import AlohaOperatorSim  # noqa: F401, F403
 from .franka_dual_operator import FrankaDualOperator  # noqa: F401, F403
 from .franka_operator import FrankaOperator  # noqa: F401, F403
 from .oli_operator import OliOperator  # noqa: F401, F403
+from .rebot_dual_operator import RebotDualOperator  # noqa: F401, F403
 from .tron2_operator import Tron2Operator  # noqa: F401, F403
 from .ur_operator import UROperator  # noqa: F401, F403

--- a/fluxvla/engines/operators/rebot_dual_operator.py
+++ b/fluxvla/engines/operators/rebot_dual_operator.py
@@ -1,0 +1,206 @@
+# Copyright 2026 Limx Dynamics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""ROS operator for a dual-arm reBot."""
+
+import time
+
+import numpy as np
+
+from fluxvla.engines.operators.base_operator import BaseOperator
+from fluxvla.engines.utils.root import OPERATORS
+
+JOINT_NAMES = [
+    'shoulder_pan',
+    'shoulder_lift',
+    'elbow_flex',
+    'wrist_flex',
+    'wrist_yaw',
+    'wrist_roll',
+    'gripper',
+]
+
+
+@OPERATORS.register_module()
+class RebotDualOperator(BaseOperator):
+    """Synchronize reBot observations and publish 7-D commands per arm."""
+
+    def __init__(
+        self,
+        img_left_topic='/camera_left_wrist/color/image_raw',
+        img_right_topic='/camera_right_wrist/color/image_raw',
+        img_front_topic='/camera_front/color/image_raw',
+        puppet_arm_left_topic='/left_arm/joint_states',
+        puppet_arm_right_topic='/right_arm/joint_states',
+        puppet_arm_left_cmd_topic=(
+            '/left_arm/rebot_joint_controller/target_joint_state'),
+        puppet_arm_right_cmd_topic=(
+            '/right_arm/rebot_joint_controller/target_joint_state'),
+        sync_slop=0.05,
+        sync_warning_enabled=True,
+        sync_warning_target_hz=30.0,
+        publish_rate=30,
+        arm_steps_length=None,
+        home_timeout=15.0,
+        image_encoding='rgb8',
+    ):
+        self.img_left_topic = img_left_topic
+        self.img_right_topic = img_right_topic
+        self.img_front_topic = img_front_topic
+        self.puppet_arm_left_topic = puppet_arm_left_topic
+        self.puppet_arm_right_topic = puppet_arm_right_topic
+        self.puppet_arm_left_cmd_topic = puppet_arm_left_cmd_topic
+        self.puppet_arm_right_cmd_topic = puppet_arm_right_cmd_topic
+        self.command_mode = 'joint'
+        self.publish_rate = int(publish_rate)
+        self.home_timeout = float(home_timeout)
+        if self.publish_rate <= 0:
+            raise ValueError('publish_rate must be positive')
+        if self.home_timeout <= 0:
+            raise ValueError('home_timeout must be positive')
+        if arm_steps_length is None:
+            arm_steps_length = [0.02] * len(JOINT_NAMES)
+        self.arm_steps_length = np.asarray(arm_steps_length, dtype=np.float32)
+        if self.arm_steps_length.shape != (len(JOINT_NAMES), ):
+            raise ValueError('arm_steps_length must contain seven values')
+        if np.any(self.arm_steps_length <= 0):
+            raise ValueError('arm_steps_length values must be positive')
+
+        super().__init__(
+            sync_slop=sync_slop,
+            sync_queue_size=30,
+            synced_frame_queue_size=10,
+            sync_warning_enabled=sync_warning_enabled,
+            sync_warning_target_hz=sync_warning_target_hz,
+            image_encoding=image_encoding)
+        self.left_joint_pub = None
+        self.right_joint_pub = None
+        self._init_ros()
+
+    def _init_ros(self):
+        """Initialize synchronized subscribers and command publishers."""
+        import rospy
+        from sensor_msgs.msg import JointState
+
+        rospy.init_node('rebot_dual_operator', anonymous=True)
+        self.setup_observation_sync(self.build_observation_specs())
+        self.left_joint_pub = rospy.Publisher(
+            self.puppet_arm_left_cmd_topic, JointState, queue_size=10)
+        self.right_joint_pub = rospy.Publisher(
+            self.puppet_arm_right_cmd_topic, JointState, queue_size=10)
+
+    def build_observation_specs(self):
+        """Return the five streams that form one observation."""
+        from sensor_msgs.msg import Image, JointState
+
+        return [
+            ('img_front', self.img_front_topic, Image),
+            ('img_left', self.img_left_topic, Image),
+            ('img_right', self.img_right_topic, Image),
+            ('left_arm', self.puppet_arm_left_topic, JointState),
+            ('right_arm', self.puppet_arm_right_topic, JointState),
+        ]
+
+    @staticmethod
+    def joint_positions(message):
+        """Return a JointState in the canonical reBot order."""
+        if message.name:
+            positions_by_name = dict(zip(message.name, message.position))
+            if all(name in positions_by_name for name in JOINT_NAMES):
+                values = [positions_by_name[name] for name in JOINT_NAMES]
+            elif all(f'joint{index}' in positions_by_name
+                     for index in range(len(JOINT_NAMES))):
+                values = [
+                    positions_by_name[f'joint{index}']
+                    for index in range(len(JOINT_NAMES))
+                ]
+            else:
+                raise ValueError(
+                    'reBot JointState names must be shoulder_pan..gripper or '
+                    'joint0..joint6')
+        else:
+            values = list(message.position)
+        if len(values) != len(JOINT_NAMES):
+            raise ValueError('reBot JointState must contain seven positions')
+        positions = np.asarray(values, dtype=np.float32)
+        if not np.isfinite(positions).all():
+            raise ValueError('reBot JointState contains NaN or infinity')
+        return positions
+
+    def send_joints(self, arm_targets):
+        """Publish left and/or right joint targets in canonical order."""
+        unsupported = set(arm_targets) - {'left', 'right'}
+        if unsupported:
+            raise ValueError(f'Unsupported reBot arm target(s): {unsupported}')
+
+        import rospy
+
+        stamp = rospy.Time.now()
+        if 'left' in arm_targets:
+            self.left_joint_pub.publish(
+                self._build_joint_state(arm_targets['left'], stamp))
+        if 'right' in arm_targets:
+            self.right_joint_pub.publish(
+                self._build_joint_state(arm_targets['right'], stamp))
+
+    @staticmethod
+    def _build_joint_state(positions, stamp):
+        from sensor_msgs.msg import JointState
+
+        if len(positions) != len(JOINT_NAMES):
+            raise ValueError('reBot joint command must contain seven values')
+        message = JointState()
+        message.header.stamp = stamp
+        message.name = list(JOINT_NAMES)
+        message.position = [float(value) for value in positions]
+        return message
+
+    def gohome(self, prepare_pose):
+        """Interpolate both arms to an explicitly configured prepare pose."""
+        import rospy
+
+        targets = np.asarray(prepare_pose, dtype=np.float32)
+        if targets.shape != (2, len(JOINT_NAMES)):
+            raise ValueError('prepare_pose must have shape [2, 7]')
+
+        deadline = time.monotonic() + self.home_timeout
+        rate = rospy.Rate(self.publish_rate)
+        while not rospy.is_shutdown():
+            frame = self.get_frame()
+            if frame:
+                current = np.stack([
+                    self.joint_positions(frame['left_arm']),
+                    self.joint_positions(frame['right_arm']),
+                ])
+                break
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    'Timed out waiting for a synchronized reBot observation')
+            rate.sleep()
+        else:
+            return
+
+        max_step_count = np.max(
+            np.abs(targets - current) / self.arm_steps_length)
+        steps = max(1, int(np.ceil(max_step_count)))
+        fractions = np.linspace(0.0, 1.0, steps + 1, dtype=np.float32)[1:]
+        trajectories = current[None] + fractions[:, None, None] * (
+            targets - current)[None]
+        self.clear_observation_queues()
+        self.execute_trajectory(
+            arm_trajectories={
+                'left': trajectories[:, 0],
+                'right': trajectories[:, 1],
+            },
+            dt=1.0 / self.publish_rate)
+        self.clear_observation_queues()

--- a/fluxvla/engines/runners/__init__.py
+++ b/fluxvla/engines/runners/__init__.py
@@ -34,6 +34,8 @@ except ImportError as exc:
 
 from .oli_inference_runner import OliInferenceRunner  # noqa: F401, F403
 from .oli_rtc_inference_runner import OliRTCInferenceRunner  # noqa: F401, F403
+from .rebot_dual_inference_runner import \
+    RebotDualInferenceRunner  # noqa: F401, F403
 from .tron2_inference_runner import Tron2InferenceRunner  # noqa: F401, F403
 from .tron2_rtc_inference_runner import \
     Tron2RTCInferenceRunner  # noqa: F401, F403

--- a/fluxvla/engines/runners/rebot_dual_inference_runner.py
+++ b/fluxvla/engines/runners/rebot_dual_inference_runner.py
@@ -1,0 +1,130 @@
+# Copyright 2026 Limx Dynamics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Inference runner for a dual-arm reBot."""
+
+from typing import Dict
+
+import numpy as np
+
+from fluxvla.engines.utils.root import RUNNERS
+from .base_inference_runner import BaseInferenceRunner
+
+
+@RUNNERS.register_module()
+class RebotDualInferenceRunner(BaseInferenceRunner):
+    """Run the reBot 14-D observation and joint-command loop."""
+
+    def __init__(self, prepare_pose=None, *args, **kwargs):
+        if 'camera_names' not in kwargs or kwargs['camera_names'] is None:
+            kwargs['camera_names'] = [
+                'cam_front', 'cam_wrist_left', 'cam_wrist_right'
+            ]
+        if 'operator' not in kwargs or kwargs['operator'] is None:
+            kwargs['operator'] = dict(
+                type='RebotDualOperator',
+                img_front_topic='/camera_front/color/image_raw',
+                img_left_topic='/camera_left_wrist/color/image_raw',
+                img_right_topic='/camera_right_wrist/color/image_raw',
+                puppet_arm_left_topic='/left_arm/joint_states',
+                puppet_arm_right_topic='/right_arm/joint_states',
+                puppet_arm_left_cmd_topic=(
+                    '/left_arm/rebot_joint_controller/target_joint_state'),
+                puppet_arm_right_cmd_topic=(
+                    '/right_arm/rebot_joint_controller/target_joint_state'))
+        if 'task_descriptions' not in kwargs or kwargs[
+                'task_descriptions'] is None:
+            kwargs['task_descriptions'] = {
+                '1': 'Complete the requested bimanual task.'
+            }
+
+        super().__init__(*args, **kwargs)
+        if len(self.camera_names) != 3:
+            raise ValueError('reBot inference requires exactly three cameras')
+        self.dt = 1.0 / self.publish_rate
+        self.prepare_pose = prepare_pose
+
+    def get_ros_observation(self) -> Dict:
+        """Wait for one synchronized three-camera, dual-arm observation."""
+        import rospy
+
+        from ..utils import initialize_overwatch
+
+        logger = initialize_overwatch(__name__)
+        rate = rospy.Rate(self.publish_rate)
+        should_log = True
+        rate.sleep()
+        while not rospy.is_shutdown():
+            frame = self.ros_operator.get_frame()
+            if frame:
+                return frame
+            if should_log:
+                logger.info('Synchronization failed in get_ros_observation')
+                should_log = False
+            rate.sleep()
+        return {}
+
+    def update_observation_window(self) -> Dict:
+        """Build the model observation using the canonical left-right order."""
+        from collections import deque
+
+        if self.observation_window is None:
+            self.observation_window = deque(maxlen=2)
+            dummy = {'qpos': None}
+            dummy.update({name: None for name in self.camera_names})
+            self.observation_window.append(dummy)
+
+        frame = self.get_ros_observation()
+        qpos = np.concatenate([
+            self.ros_operator.joint_positions(frame['left_arm']),
+            self.ros_operator.joint_positions(frame['right_arm']),
+        ])
+        observation = {
+            'qpos': qpos,
+            self.camera_names[0]:
+            self._apply_jpeg_compression(frame['img_front']),
+            self.camera_names[1]:
+            self._apply_jpeg_compression(frame['img_left']),
+            self.camera_names[2]:
+            self._apply_jpeg_compression(frame['img_right']),
+        }
+        self.observation_window.append(observation)
+        return observation
+
+    def _move_to_prepare_pose(self):
+        """Move only when a deployment supplies a verified prepare pose."""
+        if self.prepare_pose is not None:
+            self.ros_operator.gohome(self.prepare_pose)
+            self.observation_window = None
+
+    def _execute_actions(self, actions, rate):
+        """Execute a 14-D action chunk as two seven-joint trajectories."""
+        del rate
+        if self.disable_puppet_arm:
+            return
+        actions = np.asarray(actions)
+        if actions.ndim != 2 or actions.shape[1] < 14:
+            raise ValueError(
+                f'reBot actions must have shape [T, >=14], got {actions.shape}'
+            )
+        self.ros_operator.execute_trajectory(
+            arm_trajectories={
+                'left': actions[:, :7],
+                'right': actions[:, 7:14],
+            },
+            dt=self.dt)
+
+    def cleanup(self):
+        """Stop an active trajectory before base runner cleanup."""
+        self.ros_operator.stop_trajectory()
+        super().cleanup()

--- a/test/test_engines/test_rebot.py
+++ b/test/test_engines/test_rebot.py
@@ -1,0 +1,208 @@
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import numpy as np
+import torch
+from mmengine import Config
+
+ROOT = Path(__file__).resolve().parents[2]
+CONFIG_PATH = ROOT / 'configs/pi05/pi05_rebot_dual_inference.py'
+
+
+def test_rebot_components_registered():
+    import fluxvla.engines.operators  # noqa: F401
+    import fluxvla.engines.runners  # noqa: F401
+    from fluxvla.engines.operators.aloha_operator import AlohaOperator
+    from fluxvla.engines.operators.base_operator import BaseOperator
+    from fluxvla.engines.operators.rebot_dual_operator import RebotDualOperator
+    from fluxvla.engines.runners.aloha_inference_runner import \
+        AlohaInferenceRunner
+    from fluxvla.engines.runners.base_inference_runner import \
+        BaseInferenceRunner
+    from fluxvla.engines.runners.rebot_dual_inference_runner import \
+        RebotDualInferenceRunner
+    from fluxvla.engines.utils.root import OPERATORS, RUNNERS
+
+    assert OPERATORS.get('RebotDualOperator') is not None
+    assert RUNNERS.get('RebotDualInferenceRunner') is not None
+    assert issubclass(RebotDualOperator, BaseOperator)
+    assert not issubclass(RebotDualOperator, AlohaOperator)
+    assert issubclass(RebotDualInferenceRunner, BaseInferenceRunner)
+    assert not issubclass(RebotDualInferenceRunner, AlohaInferenceRunner)
+
+
+def test_rebot_config_is_standalone_and_uses_14d_contract():
+    source = CONFIG_PATH.read_text(encoding='utf-8')
+    cfg = Config.fromfile(CONFIG_PATH)
+
+    assert '_base_' not in source
+    assert cfg.inference.type == 'RebotDualInferenceRunner'
+    assert cfg.inference.operator.type == 'RebotDualOperator'
+    assert cfg.inference_model.ori_action_dim == 14
+    assert cfg.inference.state_dim == 14
+    assert cfg.inference.dataset.img_keys == [
+        'cam_front', 'cam_wrist_left', 'cam_wrist_right'
+    ]
+    assert cfg.inference.denormalize_action.type == 'DenormalizeDeltaAction'
+    assert cfg.inference.dataset.transforms[0].state_key == 'proprio'
+    assert 'norm_stats_path' not in cfg.inference
+    assert 'norm_stats_key' not in cfg.inference.dataset
+    assert 'action_stats_key' not in cfg.inference.denormalize_action
+    assert 'pick_place' not in source
+    expected_mask = [True] * 6 + [False] + [True] * 6 + [False]
+    assert cfg.inference.denormalize_action.delta_action_mask == expected_mask
+
+
+def test_rebot_runner_preserves_continuous_gripper_angles():
+    from fluxvla.engines.runners.rebot_dual_inference_runner import \
+        RebotDualInferenceRunner
+
+    runner = object.__new__(RebotDualInferenceRunner)
+    expected = np.zeros((2, 14), dtype=np.float32)
+    expected[:, [6, 13]] = -4.7
+    runner._use_remote = False
+    runner.action_chunk = 2
+    runner._action_ctx = SimpleNamespace(state=np.zeros(14))
+    runner.denormalize_action = lambda _: expected.copy()
+
+    actual = runner._postprocess_actions(torch.zeros((1, 2, 32)))
+
+    assert np.array_equal(actual, expected)
+
+
+def test_rebot_uses_standard_private_statistics_layout():
+    from fluxvla.transforms.normalize import DenormalizeDeltaAction
+
+    mask = [True] * 6 + [False] + [True] * 6 + [False]
+    stats = {
+        'private': {
+            'action': {
+                'q01': [-1.0] * 14,
+                'q99': [1.0] * 14,
+            }
+        }
+    }
+    transform = DenormalizeDeltaAction(
+        norm_stats=stats,
+        norm_type='quantile',
+        action_dim=14,
+        delta_action_mask=mask)
+    state = np.arange(14, dtype=np.float32)
+
+    actions = transform({
+        'action': np.zeros((1, 2, 32), dtype=np.float32),
+        'state': state,
+    })
+
+    expected = np.broadcast_to(np.where(mask, state, 0.0), (2, 14))
+    assert np.array_equal(actions, expected)
+
+
+def test_rebot_operator_publishes_canonical_joint_names():
+    from fluxvla.engines.operators.rebot_dual_operator import RebotDualOperator
+
+    class JointState:
+
+        def __init__(self):
+            self.header = SimpleNamespace(stamp=None)
+            self.name = []
+            self.position = []
+
+    class Publisher:
+
+        def __init__(self):
+            self.messages = []
+
+        def publish(self, message):
+            self.messages.append(message)
+
+    operator = object.__new__(RebotDualOperator)
+    operator.left_joint_pub = Publisher()
+    operator.right_joint_pub = Publisher()
+    rospy = SimpleNamespace(Time=SimpleNamespace(now=lambda: 123.0))
+    sensor_msgs = SimpleNamespace(msg=SimpleNamespace(JointState=JointState))
+
+    with patch.dict(
+            'sys.modules', {
+                'rospy': rospy,
+                'sensor_msgs': sensor_msgs,
+                'sensor_msgs.msg': sensor_msgs.msg,
+            }):
+        operator.send_joints({'left': range(7), 'right': range(7, 14)})
+
+    expected_names = [
+        'shoulder_pan',
+        'shoulder_lift',
+        'elbow_flex',
+        'wrist_flex',
+        'wrist_yaw',
+        'wrist_roll',
+        'gripper',
+    ]
+    left = operator.left_joint_pub.messages[0]
+    right = operator.right_joint_pub.messages[0]
+    assert left.header.stamp == right.header.stamp == 123.0
+    assert left.name == right.name == expected_names
+    assert left.position == list(range(7))
+    assert right.position == list(range(7, 14))
+
+
+def test_rebot_operator_reorders_joint_states_by_name():
+    from fluxvla.engines.operators.rebot_dual_operator import (
+        JOINT_NAMES, RebotDualOperator)
+
+    message = SimpleNamespace(
+        name=list(reversed(JOINT_NAMES)), position=list(range(7)))
+
+    positions = RebotDualOperator.joint_positions(message)
+
+    assert np.array_equal(positions, np.arange(6, -1, -1))
+
+
+def test_rebot_operator_interpolates_explicit_prepare_pose():
+    from fluxvla.engines.operators.rebot_dual_operator import (
+        JOINT_NAMES, RebotDualOperator)
+
+    operator = object.__new__(RebotDualOperator)
+    operator.home_timeout = 1.0
+    operator.publish_rate = 30
+    operator.arm_steps_length = np.full(7, 0.5, dtype=np.float32)
+    joint_state = SimpleNamespace(name=JOINT_NAMES, position=[0.0] * 7)
+    operator.get_frame = Mock(return_value={
+        'left_arm': joint_state,
+        'right_arm': joint_state,
+    })
+    operator.clear_observation_queues = Mock()
+    operator.execute_trajectory = Mock()
+    rospy = SimpleNamespace(
+        is_shutdown=lambda: False,
+        Rate=lambda _: SimpleNamespace(sleep=lambda: None))
+    target = np.ones((2, 7), dtype=np.float32)
+
+    with patch.dict('sys.modules', {'rospy': rospy}):
+        operator.gohome(target)
+
+    kwargs = operator.execute_trajectory.call_args.kwargs
+    assert kwargs['arm_trajectories']['left'].shape == (2, 7)
+    assert np.array_equal(kwargs['arm_trajectories']['left'][-1], target[0])
+    assert np.array_equal(kwargs['arm_trajectories']['right'][-1], target[1])
+    assert kwargs['dt'] == 1.0 / 30.0
+
+
+def test_rebot_runner_splits_dual_arm_actions():
+    from fluxvla.engines.runners.rebot_dual_inference_runner import \
+        RebotDualInferenceRunner
+
+    runner = object.__new__(RebotDualInferenceRunner)
+    runner.disable_puppet_arm = False
+    runner.dt = 1.0 / 30.0
+    runner.ros_operator = SimpleNamespace(execute_trajectory=Mock())
+    actions = np.arange(42, dtype=np.float32).reshape(3, 14)
+
+    runner._execute_actions(actions, rate=None)
+
+    kwargs = runner.ros_operator.execute_trajectory.call_args.kwargs
+    assert np.array_equal(kwargs['arm_trajectories']['left'], actions[:, :7])
+    assert np.array_equal(kwargs['arm_trajectories']['right'], actions[:, 7:])
+    assert kwargs['dt'] == runner.dt


### PR DESCRIPTION
## Summary

This PR adds standalone dual-arm reBot inference support to FluxVLA.

## Changes

- Add a generic PI0.5 inference configuration for reBot.
- Add standalone reBot operator and inference runner implementations.
- Register the new operator and runner components.
- Add ROS setup and inference documentation.
- Add unit tests for reBot observation and action processing.