### PR TITLE
[Enhance] Improve Oli hand control and interactive inference

### DIFF
--- a/docs/oli_whole_body.md
+++ b/docs/oli_whole_body.md
@@ -1,8 +1,8 @@
 # Oli Whole-Body (Loco-Manipulation) Operator
 
-`OliOperator` + `OliInferenceRunner` provide a minimal whole-body inference
-path for the Oli humanoid: a head camera and 33-dim proprioceptive state in,
-a 42-dim whole-body action out.
+`OliOperator` + `OliInferenceRunner` provide a whole-body inference path for
+the Oli humanoid. The default layout uses a head camera, a 33-dim
+proprioceptive state, and a 42-dim whole-body action.
 
 ## Spaces
 
@@ -13,6 +13,29 @@ a 42-dim whole-body action out.
   - `[31:34]` `base_link` position `xyz` (absolute)
   - `[34:40]` `base_link` rotation as 6D (Zhou et al.)
   - `[40]` `left_hand_closed`, `[41]` `right_hand_closed`
+
+### Full dexterous-hand layout (MROS)
+
+Set `hand_mode='finger'` for a checkpoint trained on individual BrainCo
+finger values. In this mode, the state is **43-dim** (31 joints + 12 finger
+state values) and the action is **52-dim**. The first 40 action dimensions
+are unchanged; `[40:52]` supplies the finger values. The operator appends
+`finger_force_levels` and publishes the resulting 14-dimensional command to
+`finger_cmd_topic`.
+
+```python
+operator=dict(
+    type='OliOperator',
+    control_backend='mros',
+    left_wrist_rgb_topic='/left_wrist_camera/color/image_raw/compressed',
+    finger_state_topic='/brainco1/hand/state',
+    finger_cmd_topic='/brainco1/hand/cmd',
+    hand_mode='finger',
+)
+```
+
+`hand_mode='finger'` is MROS-only. Use `hand_mode='binary'` for existing
+42-dim open/close-hand checkpoints.
 
 ### Canonical 31-joint order
 
@@ -58,10 +81,18 @@ right_wrist_roll_joint
 
 ## Transport
 
-Sensor input is read over **ROS (rospy)**; control output is sent over the
-**LimX WebSocket JSON protocol** (`request_servoj` for joints), mirroring
-`Tron2Operator`. Both `rospy` and `websocket-client` are imported lazily, so
-the modules import without any middleware installed.
+`OliOperator` supports two transport backends:
+
+- `control_backend='websocket'`: observations arrive through ROS (`rospy`),
+  while commands use the LimX WebSocket JSON protocol (`request_servoj` for
+  joints).
+- `control_backend='mros'`: compressed images, joint state, and finger state
+  arrive through MROS; whole-body commands are published as `TeleopMsg` on
+  `teleop_wbt_topic`, and hand commands as `Float32Array` on
+  `finger_cmd_topic`.
+
+Middleware imports remain lazy, so importing the module itself does not
+require a running robot stack.
 
 ### ROS topics (defaults)
 
@@ -80,12 +111,36 @@ latest available image and joint state without timestamp synchronization
 The base-pose (`request_base_pose`) and hand (`request_hand_cmd`) WebSocket
 request titles are **robot-SDK specific** and are not part of the public LimX
 protocol. Adapt their titles/payloads in
-`fluxvla/engines/operators/oli_operator.py` (`_send_base_pose`, `_send_hands`)
-to your controller.
+`fluxvla/engines/operators/oli_operator.py` (`_send_base_pose`,
+`_send_hand_action`) to your controller.
 
 Note: `disable_puppet_arm=True` only makes the runner skip sending actions; it
 does NOT make initialization hardware-free — the operator still connects ROS
 and WebSocket on construction.
+
+## Prompt, prepare pose, and pause
+
+`OliInferenceRunner` treats one execution as one predicted action chunk,
+optionally truncated by `execute_horizon`. In interactive mode it first asks
+for a prompt ID and then for the number of chunks to execute.
+
+Set `prepare_pose` to a 33-dimensional binary-hand state or a 43-dimensional
+finger-hand state. When `prepare_pose_prompt_id` is configured, entering that
+ID smoothly moves the MROS robot to the pose over
+`prepare_pose_duration_sec`, then returns to prompt selection.
+
+With `interactive=True`, type `p` and press Enter while actions are running to
+pause after the current chunk and return to prompt selection. The configured
+`default_execution_count` is the default number of chunks for one interactive
+selection.
+
+With `interactive=False`, the runner never reads stdin. It continuously uses
+`default_prompt_id`, preserves cross-chunk history, and ignores
+`default_execution_count`. The RTC runner also keeps one scheduler and one
+producer/actor pair alive, preserving its action prefix across chunks. Use
+Ctrl+C to stop either runner cleanly. When nonzero, `max_publish_step` limits
+the action steps in a continuous run or one interactive prompt selection; zero
+disables the limit.
 
 ## Run
 

--- a/fluxvla/datasets/parquet_dataset.py
+++ b/fluxvla/datasets/parquet_dataset.py
@@ -636,6 +636,7 @@ class PrivateInferenceDataset:
                  norm_stats: str,
                  transforms: List[Dict],
                  model_path: str,
+                 statistic_name: str = 'private',
                  img_keys: List[str] = ['agentview_image'],
                  center_crop: bool = False,
                  resize_size: int = 224,
@@ -656,6 +657,7 @@ class PrivateInferenceDataset:
                 self.norm_stats = json.load(f)
         else:
             self.norm_stats = norm_stats
+        self.statistic_name = statistic_name
         self.img_keys = img_keys
         self.center_crop = center_crop
         self.resize_size = resize_size
@@ -676,7 +678,7 @@ class PrivateInferenceDataset:
             images=imgs,
             task_description=data.get('task_description',
                                       'No task description provided'),
-            stats=self.norm_stats['private'],
+            stats=self.norm_stats[self.statistic_name],
             states=data['qpos'])
         if self.embodiment_id is not None:
             inputs['embodiment_ids'] = np.array(

--- a/fluxvla/engines/operators/oli_operator.py
+++ b/fluxvla/engines/operators/oli_operator.py
@@ -161,13 +161,16 @@ class OliOperator(BaseOperator):
     on ``/teleop_cmd_WBT``.  Both modes share BaseOperator lifecycle and
     trajectory state.
 
-    state (33-dim): 31 joint positions + 2 hand-closed flags.
-    action (42-dim):
+    Default state (33-dim): 31 joint positions + 2 hand-closed flags.
+    Default action (42-dim):
         [0:31]  joint position commands (q)
         [31:34] base_link position (xyz, absolute)
         [34:40] base_link rotation (rot6d)
         [40]    left_hand_closed
         [41]    right_hand_closed
+
+    With ``hand_mode='finger'`` in MROS mode, the state/action instead carry
+    the 12 individual finger values: 43-dim state and 52-dim action.
     """
 
     def __init__(self,
@@ -179,9 +182,10 @@ class OliOperator(BaseOperator):
                  control_backend='websocket',
                  left_wrist_rgb_topic=None,
                  finger_state_topic='/brainco1/hand/state',
-                 finger_cmd_topic='/brainco1/hand/cmd_vla',
+                 finger_cmd_topic='/brainco1/hand/cmd',
                  teleop_wbt_topic='/teleop_cmd_WBT',
-                 finger_force_levels=None):
+                 finger_force_levels=None,
+                 hand_mode: str = 'binary'):
         """Initialize OliOperator.
 
         Args:
@@ -199,10 +203,18 @@ class OliOperator(BaseOperator):
             teleop_wbt_topic (str): Whole-body command topic in MROS mode.
             finger_force_levels (tuple, optional): Left/right hand force
                 levels. Defaults to (3, 3) for WebSocket and (2, 2) for MROS.
+            hand_mode (str): ``binary`` uses two hand-open/closed values;
+                ``finger`` uses 12 individual finger values and is supported
+                only by MROS. Defaults to ``binary``.
         """
         if control_backend not in {'websocket', 'mros'}:
             raise ValueError(
                 f'Unsupported Oli control_backend: {control_backend}')
+        if hand_mode not in {'binary', 'finger'}:
+            raise ValueError(f'Unsupported Oli hand_mode: {hand_mode}')
+        if hand_mode == 'finger' and control_backend != 'mros':
+            raise ValueError("hand_mode='finger' is only supported with "
+                             "control_backend='mros'")
 
         self.head_rgb_topic = head_rgb_topic
         self.left_wrist_rgb_topic = left_wrist_rgb_topic
@@ -211,6 +223,7 @@ class OliOperator(BaseOperator):
         self.finger_cmd_topic = finger_cmd_topic
         self.teleop_wbt_topic = teleop_wbt_topic
         self.control_backend = control_backend
+        self.hand_mode = hand_mode
         self.command_mode = 'joint'
 
         self.robot_ip = robot_ip
@@ -372,18 +385,7 @@ class OliOperator(BaseOperator):
             print('Non-finite joint positions; dropping frame')
             return False
 
-        # Hand-closed flags mirror the last sent finger command
-        # (data-collection convention), not a direct sensor reading; both are
-        # 0 before the first send_action call.
-        left_cmd_avg = float(np.mean(self.last_finger_cmd[0:12:2]))
-        right_cmd_avg = float(np.mean(self.last_finger_cmd[1:12:2]))
-        left_hand_closed = 1.0 if left_cmd_avg > 20 else 0.0
-        right_hand_closed = 1.0 if right_cmd_avg > 20 else 0.0
-
-        state = np.concatenate([
-            joint_state,
-            np.array([left_hand_closed, right_hand_closed], dtype=np.float32)
-        ])
+        state = np.concatenate([joint_state, self._get_hand_observation()])
         return (head_img, state)
 
     def _warn_get_frame_missing(self, key, message, interval=1.0):
@@ -430,7 +432,13 @@ class OliOperator(BaseOperator):
             time.sleep(0.005)
         return None
 
-    def _hand_closed_state(self):
+    def _get_hand_observation(self):
+        """Return the configured 12-dim finger or 2-dim hand observation."""
+        if self.hand_mode == 'finger':
+            return self.last_finger_state.copy()
+
+        # Binary hand state mirrors the last sent command rather than a sensor
+        # reading, matching the data-collection convention.
         left_avg = float(np.mean(self.last_finger_cmd[0:12:2]))
         right_avg = float(np.mean(self.last_finger_cmd[1:12:2]))
         return np.array([float(left_avg > 20.0),
@@ -438,7 +446,7 @@ class OliOperator(BaseOperator):
                         dtype=np.float32)
 
     def _get_mros_frame(self, timeout=0.05):
-        """Read head/wrist images and the 33-dim WBT state from MROS."""
+        """Read head/wrist images and the configured WBT state from MROS."""
         head_img = self._read_mros_compressed_rgb(self.color_subscriber,
                                                   timeout)
         if head_img is None:
@@ -484,7 +492,7 @@ class OliOperator(BaseOperator):
             if finger_state.size >= 12:
                 self.last_finger_state = finger_state[:12].copy()
 
-        state = np.concatenate([joint_state, self._hand_closed_state()])
+        state = np.concatenate([joint_state, self._get_hand_observation()])
         if left_wrist_img is None:
             return (head_img, state)
         return (head_img, left_wrist_img, state)
@@ -608,12 +616,15 @@ class OliOperator(BaseOperator):
         """Send a whole-body action through the configured transport.
 
         Args:
-            action (np.ndarray): Action vector with at least the 42 WBT dims.
+            action (np.ndarray): Action vector with at least 42 WBT dims, or
+                52 dims when ``hand_mode='finger'``.
         """
         action = np.asarray(action, dtype=np.float64)
-        if action.ndim != 1 or action.size < 42:
+        expected_dim = 52 if self.hand_mode == 'finger' else 42
+        if action.ndim != 1 or action.size < expected_dim:
             raise ValueError(
-                f'OliOperator expects a (D>=42,) action, got {action.shape}')
+                f'OliOperator expects a (D>={expected_dim},) action, got '
+                f'{action.shape}')
         if not np.all(np.isfinite(action)):
             raise ValueError('OliOperator received a non-finite action')
 
@@ -628,16 +639,13 @@ class OliOperator(BaseOperator):
         joint_cmd_q = action[0:31]
         base_pos = action[31:34]
         base_rot6d = action[34:40]
-        left_closed = float(action[40])
-        right_closed = float(action[41])
-
         self._send_joints(joint_cmd_q)
         if _is_degenerate_rot6d(base_rot6d):
             print('OliOperator: degenerate base rot6d; skipping base pose')
         else:
             base_quat_xyzw = _rot6d_to_quat_xyzw(base_rot6d)
             self._send_base_pose(base_pos, base_quat_xyzw)
-        self._send_hands(left_closed, right_closed)
+        self._send_hand_action(action[40:42])
 
     def _make_keypoint(self,
                        name,
@@ -704,7 +712,8 @@ class OliOperator(BaseOperator):
             self._make_keypoint('base_link', base_pos, base_quat)
         ]
         self.teleop_wbt_publisher.publish(teleop_msg)
-        self._send_hands(float(action[40]), float(action[41]))
+        hand_end = 52 if self.hand_mode == 'finger' else 42
+        self._send_hand_action(action[40:hand_end])
 
     def _send_joints(self, q):
         """Send 31 joint position targets via ``request_servoj``."""
@@ -742,33 +751,49 @@ class OliOperator(BaseOperator):
                 ],
             })
 
-    def _send_hands(self, left_closed, right_closed):
-        """Send dexterous-hand open/close command.
+    def _send_hand_action(self, hand_action):
+        """Convert and publish the configured 2-dim or 12-dim hand action."""
+        hand_action = np.asarray(hand_action, dtype=np.float32)
+        expected_dim = 12 if self.hand_mode == 'finger' else 2
+        if hand_action.shape != (expected_dim, ):
+            raise ValueError(
+                f'Hand action must have shape ({expected_dim},), got '
+                f'{hand_action.shape}')
+        if not np.all(np.isfinite(hand_action)):
+            raise ValueError('Hand action must be finite')
 
-        NOTE (hardware integration point): the hand-command request title is
-        robot-SDK specific. The 14-dim payload (12 finger + 2 force levels)
-        matches the data-collection convention.
-        """
-        left_val = 100.0 if left_closed >= 0.5 else 0.0
-        right_val = 100.0 if right_closed >= 0.5 else 0.0
-        finger_cmd = [0.0] * 14
-        for i in range(0, 12, 2):
-            finger_cmd[i] = left_val
-        for i in range(1, 12, 2):
-            finger_cmd[i] = right_val
-        # Indices 2/3: left/right thumb-aux fingers; always closed for grasp.
-        finger_cmd[2] = 100.0
-        finger_cmd[3] = 100.0
-        force_levels = self.finger_force_levels
-        if force_levels is None:
-            force_levels = ((2.0, 2.0) if self.control_backend == 'mros' else
-                            (3.0, 3.0))
-        if len(force_levels) != 2:
-            raise ValueError('finger_force_levels must contain 2 values')
-        finger_cmd[12] = float(force_levels[0])
-        finger_cmd[13] = float(force_levels[1])
+        if self.hand_mode == 'finger':
+            if self.control_backend != 'mros':
+                raise NotImplementedError(
+                    'Individual finger commands require the MROS backend')
+            finger_cmd = hand_action.tolist()
+            force_levels = self.finger_force_levels
+            if force_levels is None:
+                force_levels = (2.0, 2.0)
+            if len(force_levels) != 2:
+                raise ValueError('finger_force_levels must contain 2 values')
+            finger_cmd.extend(float(value) for value in force_levels)
+        else:
+            left_val = 100.0 if hand_action[0] >= 0.5 else 0.0
+            right_val = 100.0 if hand_action[1] >= 0.5 else 0.0
+            finger_cmd = [0.0] * 14
+            finger_cmd[0:12:2] = [left_val] * 6
+            finger_cmd[1:12:2] = [right_val] * 6
+            # Thumb-aux fingers and force levels follow the main-branch
+            # 14-dimensional hand-command contract.
+            finger_cmd[2] = 100.0
+            finger_cmd[3] = 100.0
+            force_levels = self.finger_force_levels
+            if force_levels is None:
+                force_levels = ((2.0,
+                                 2.0) if self.control_backend == 'mros' else
+                                (3.0, 3.0))
+            if len(force_levels) != 2:
+                raise ValueError('finger_force_levels must contain 2 values')
+            finger_cmd[12] = float(force_levels[0])
+            finger_cmd[13] = float(force_levels[1])
 
-        self.last_finger_cmd = np.array(finger_cmd, dtype=np.float32)
+        self.last_finger_cmd = np.asarray(finger_cmd, dtype=np.float32)
         if self.control_backend == 'mros':
             from mros.std_msgs.msg import Float32Array
             finger_msg = Float32Array()
@@ -801,44 +826,47 @@ class OliOperator(BaseOperator):
             values = list(np.asarray(gripper_targets).reshape(-1))
         if len(values) != 2:
             raise ValueError('Oli gripper target must contain left and right')
-        self._send_hands(float(values[0]), float(values[1]))
+        self._send_hand_action(values)
 
     def gohome(self,
-               initial_state=None,
+               prepare_pose=None,
                duration_sec=5.0,
                publish_rate=30.0,
                running_flag_fn=None):
-        """Smoothly move the MROS robot to a configured 33-dim state.
+        """Smoothly move the MROS robot to a configured WBT state.
 
-        The reset state contains 31 joint targets and two hand-closed flags.
-        Base x/y/yaw are held at the operator's current accumulated target;
-        they are not part of ``/joint/state`` and therefore are not guessed.
+        The prepare pose contains 31 joint targets plus either two hand-closed
+        flags or twelve individual finger positions. Base x/y/yaw are held at
+        the operator's current accumulated target; they are not part of
+        ``/joint/state`` and therefore are not guessed.
         """
-        if initial_state is None:
-            raise ValueError('Oli gohome requires a 33-dim initial_state')
+        if prepare_pose is None:
+            raise ValueError('Oli gohome requires a prepare_pose')
         if self.control_backend != 'mros':
             raise NotImplementedError(
-                'Oli configured-state reset currently requires MROS')
+                'Oli prepare-pose motion currently requires MROS')
 
-        target = np.asarray(initial_state, dtype=np.float64)
-        if target.shape != (33, ) or not np.all(np.isfinite(target)):
+        target = np.asarray(prepare_pose, dtype=np.float64)
+        state_dim = 43 if self.hand_mode == 'finger' else 33
+        if target.shape != (state_dim, ) or not np.all(np.isfinite(target)):
             raise ValueError(
-                'Oli initial_state must be a finite 33-dim vector')
+                f'Oli prepare_pose must be a finite {state_dim}-dim vector')
         duration_sec = float(duration_sec)
         publish_rate = float(publish_rate)
         if duration_sec <= 0 or publish_rate <= 0:
             raise ValueError(
-                'Reset duration and publish rate must be positive')
+                'Prepare-pose duration and publish rate must be positive')
 
         joint_msg = self._read_mros_message(
             self.joint_state_subscriber, timeout=1.0)
         if joint_msg is None:
             raise RuntimeError(
                 f'No joint state received from {self.joint_state_topic}; '
-                'reset was not started')
+                'prepare-pose motion was not started')
         start_q = np.asarray(joint_msg.q, dtype=np.float64)
         if start_q.size < 31 or not np.all(np.isfinite(start_q[:31])):
-            raise RuntimeError('Invalid joint state; reset was not started')
+            raise RuntimeError(
+                'Invalid joint state; prepare-pose motion was not started')
         start_q = start_q[:31].copy()
 
         steps = max(1, int(round(duration_sec * publish_rate)))
@@ -850,11 +878,15 @@ class OliOperator(BaseOperator):
                 break
             ratio = step / steps
             blend = ratio**3 * (10.0 + ratio * (-15.0 + 6.0 * ratio))
-            action = np.zeros(42, dtype=np.float64)
+            action = np.zeros(
+                52 if self.hand_mode == 'finger' else 42, dtype=np.float64)
             action[:31] = start_q + blend * (target[:31] - start_q)
             action[31:34] = [0.0, 0.0, self._accum_base_pos[2]]
             action[34:40] = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0]
-            action[40:42] = target[31:33]
+            if self.hand_mode == 'finger':
+                action[40:52] = target[31:43]
+            else:
+                action[40:42] = target[31:33]
             self.send_action(action)
 
             next_publish_time += period
@@ -863,9 +895,9 @@ class OliOperator(BaseOperator):
             completed = True
 
         if not completed:
-            raise RuntimeError('Oli initial-state reset was interrupted')
+            raise RuntimeError('Oli prepare-pose motion was interrupted')
         print(
-            f'[reset] Reached configured Oli initial state in '
+            f'[prepare] Reached configured Oli prepare pose in '
             f'{duration_sec:.1f}s ({steps} steps).',
             flush=True)
         return target.copy()

--- a/fluxvla/engines/runners/base_inference_runner.py
+++ b/fluxvla/engines/runners/base_inference_runner.py
@@ -521,11 +521,12 @@ class BaseInferenceRunner:
         Returns:
             np.ndarray: Denormalized actions, truncated to action_chunk.
         """
+        action_numpy = raw_action.float().cpu().numpy()
         if self._use_remote:
-            return raw_action.cpu().numpy()[:self.action_chunk]
+            return action_numpy[:self.action_chunk]
         denormalized = self.denormalize_action(
             dict(
-                action=raw_action.cpu().numpy(),
+                action=action_numpy,
                 state=getattr(self._action_ctx, 'state', None)))
         return denormalized[:self.action_chunk]
 

--- a/fluxvla/engines/runners/base_inference_runner.py
+++ b/fluxvla/engines/runners/base_inference_runner.py
@@ -14,6 +14,8 @@
 
 import io
 import os
+import select
+import sys
 import threading
 import time
 from pathlib import Path
@@ -75,6 +77,8 @@ class BaseInferenceRunner:
             server.  Keys: ``server_host``, ``server_port``, ``timeout_s``,
             ``serializer``, ``compress``, ``enable_profiling``.
     """
+
+    _PAUSE_COMMAND = 'p'
 
     def __init__(self,
                  cfg: Dict = None,
@@ -363,6 +367,12 @@ class BaseInferenceRunner:
                 actions = self._postprocess_actions(raw_action)
                 self._execute_actions(actions, rate)
 
+                if self._poll_keyboard_pause():
+                    self.reset_inference_history()
+                    overwatch.info('Paused after the current action chunk; '
+                                   'waiting for the next instruction.')
+                    return
+
                 self._prev_ctx = self._action_ctx
                 t += (
                     getattr(self, 'execute_horizon', None)
@@ -518,6 +528,37 @@ class BaseInferenceRunner:
                 action=raw_action.cpu().numpy(),
                 state=getattr(self._action_ctx, 'state', None)))
         return denormalized[:self.action_chunk]
+
+    def reset_inference_history(self) -> None:
+        """Discard temporal state after an out-of-band robot reset.
+
+        Evaluation resets move the robot independently of the policy.  The
+        previous action context and observation window therefore no longer
+        describe the current robot state and must not be used for the next
+        inference chunk.
+        """
+        self._prev_ctx = None
+        self._action_ctx = SimpleNamespace()
+        self.observation_window = None
+
+    def _poll_keyboard_pause(self) -> bool:
+        """Return True when the terminal requests a pause after this chunk.
+
+        A terminal is line-buffered, so type ``p`` and press Enter while a
+        chunk is running. The command is consumed after that chunk completes;
+        no asynchronous input thread is required.
+        """
+        if not sys.stdin.isatty():
+            return False
+        try:
+            readable, _, _ = select.select([sys.stdin], [], [], 0)
+        except (OSError, ValueError):
+            return False
+        if not readable:
+            return False
+
+        command = sys.stdin.readline().strip().lower()
+        return command == self._PAUSE_COMMAND
 
     def _get_user_task_instruction(self, default_instruction: str) -> str:
         """Get task instruction from user input.

--- a/fluxvla/engines/runners/oli_inference_runner.py
+++ b/fluxvla/engines/runners/oli_inference_runner.py
@@ -34,9 +34,10 @@ class _ShutdownRequested(Exception):
 class OliInferenceRunner(BaseInferenceRunner):
     """Runner for Oli whole-body (loco-manipulation) inference.
 
-    Supports one or two cameras, a 33-dim state (31 joints + 2 hand-closed),
-    and a 42-dim action (31 joint q + 9 base pose + 2 hand-closed). Each
-    predicted action step is sent to ``OliOperator`` with time-based control.
+    Supports one or two cameras and either the legacy 33-dim state/42-dim
+    action hand-open/closed representation or the MROS 43-dim state/52-dim
+    individual-finger representation. Each predicted action step is sent to
+    ``OliOperator`` with time-based control.
 
     No RTC, interpolation, async execution, or done-driven prompt switching.
     Interactive execution selects a prompt ID and a positive execution count;
@@ -50,9 +51,9 @@ class OliInferenceRunner(BaseInferenceRunner):
                  default_prompt_id: str = None,
                  default_execution_count: int = 1,
                  apply_jpeg_compression: bool = False,
-                 zero_prompt_resets: bool = False,
-                 initial_state=None,
-                 reset_duration_sec: float = 5.0,
+                 prepare_pose=None,
+                 prepare_pose_duration_sec: float = 5.0,
+                 prepare_pose_prompt_id: str = None,
                  *args,
                  **kwargs):
         self.execute_horizon = execute_horizon
@@ -60,23 +61,27 @@ class OliInferenceRunner(BaseInferenceRunner):
         self.default_prompt_id = default_prompt_id
         self.default_execution_count = int(default_execution_count)
         self.apply_jpeg_compression = bool(apply_jpeg_compression)
-        self.zero_prompt_resets = bool(zero_prompt_resets)
-        self.initial_state = (None if initial_state is None else np.asarray(
-            initial_state, dtype=np.float64))
-        self.reset_duration_sec = float(reset_duration_sec)
+        self.prepare_pose = (None if prepare_pose is None else np.asarray(
+            prepare_pose, dtype=np.float64))
+        self.prepare_pose_duration_sec = float(prepare_pose_duration_sec)
+        self.prepare_pose_prompt_id = (None if prepare_pose_prompt_id is None
+                                       else str(prepare_pose_prompt_id))
         if self.execute_horizon is not None and self.execute_horizon <= 0:
             raise ValueError('execute_horizon must be positive or None')
-        if self.default_execution_count <= 0:
+        if self.interactive and self.default_execution_count <= 0:
             raise ValueError('default_execution_count must be positive')
-        if self.initial_state is not None:
-            if self.initial_state.shape != (33, ):
+        if self.prepare_pose is not None:
+            if self.prepare_pose.shape not in ((33, ), (43, )):
                 raise ValueError(
-                    'Oli initial_state must contain 31 joints and 2 hand '
-                    f'flags, got shape {self.initial_state.shape}')
-            if not np.all(np.isfinite(self.initial_state)):
-                raise ValueError('Oli initial_state must be finite')
-        if self.reset_duration_sec <= 0:
-            raise ValueError('reset_duration_sec must be positive')
+                    'Oli prepare_pose must contain 31 joints and either 2 '
+                    'hand flags or 12 finger positions, got shape '
+                    f'{self.prepare_pose.shape}')
+            if not np.all(np.isfinite(self.prepare_pose)):
+                raise ValueError('Oli prepare_pose must be finite')
+        if self.prepare_pose_duration_sec <= 0:
+            raise ValueError('prepare_pose_duration_sec must be positive')
+        if self.prepare_pose_prompt_id == '':
+            raise ValueError('prepare_pose_prompt_id must not be empty')
 
         if 'camera_names' not in kwargs or kwargs['camera_names'] is None:
             kwargs['camera_names'] = ['head']
@@ -98,6 +103,14 @@ class OliInferenceRunner(BaseInferenceRunner):
 
         super().__init__(*args, **kwargs)
 
+        if self.prepare_pose is not None:
+            hand_mode = getattr(self.ros_operator, 'hand_mode', 'binary')
+            state_dim = 43 if hand_mode == 'finger' else 33
+            if self.prepare_pose.shape != (state_dim, ):
+                raise ValueError(
+                    f'Oli prepare_pose must have shape ({state_dim},) for '
+                    'the configured hand representation')
+
         if not self.task_descriptions:
             raise ValueError('task_descriptions must not be empty')
         if self.default_prompt_id is None:
@@ -107,14 +120,14 @@ class OliInferenceRunner(BaseInferenceRunner):
             raise ValueError(
                 f'default_prompt_id {self.default_prompt_id!r} is not in '
                 f'task_descriptions={list(self.task_descriptions)}')
-        if self.zero_prompt_resets:
-            if self.initial_state is None:
+        if self.prepare_pose_prompt_id is not None:
+            if self.prepare_pose is None:
+                raise ValueError('prepare_pose is required when '
+                                 'prepare_pose_prompt_id is configured')
+            if self.prepare_pose_prompt_id in self.task_descriptions:
                 raise ValueError(
-                    'initial_state is required when zero_prompt_resets=True')
-            if self.default_prompt_id == '0':
-                raise ValueError(
-                    'default_prompt_id cannot be 0 when 0 is the reset '
-                    'command')
+                    f'prepare_pose_prompt_id {self.prepare_pose_prompt_id!r} '
+                    'conflicts with a task prompt ID')
 
         self._running = True
         self._dt = 1.0 / self.publish_rate
@@ -127,6 +140,14 @@ class OliInferenceRunner(BaseInferenceRunner):
         """Handle SIGINT for graceful shutdown."""
         print('\nShutdown requested...')
         self._running = False
+
+    def _handle_keyboard_pause(self):
+        """Return an interactive run to prompt selection at a safe boundary."""
+        self.reset_inference_history()
+        print(
+            '[pause] Paused after the current action chunk; '
+            'returning to prompt selection.',
+            flush=True)
 
     def _get_task_description(self, task_id: str) -> str:
         """Fall back to the first configured Oli task rather than the base
@@ -150,11 +171,13 @@ class OliInferenceRunner(BaseInferenceRunner):
             return [description] * self.default_execution_count
 
         prompt_ids = ', '.join(self.task_descriptions)
-        reset_hint = '; 0 resets robot' if self.zero_prompt_resets else ''
+        prepare_hint = (
+            f'; {self.prepare_pose_prompt_id} moves to prepare pose'
+            if self.prepare_pose_prompt_id is not None else '')
         while self._running:
             try:
                 value = input(f'Prompt ID [{self.default_prompt_id}] '
-                              f'(available: {prompt_ids}{reset_hint}; '
+                              f'(available: {prompt_ids}{prepare_hint}; '
                               'q to quit): ')
             except (EOFError, KeyboardInterrupt):
                 self._running = False
@@ -165,9 +188,9 @@ class OliInferenceRunner(BaseInferenceRunner):
                 return []
             if prompt_id == '':
                 prompt_id = self.default_prompt_id
-            if prompt_id == '0' and self.zero_prompt_resets:
+            if prompt_id == self.prepare_pose_prompt_id:
                 self._move_to_prepare_pose()
-                print('[reset] Oli initial state restored.', flush=True)
+                print('[prepare] Oli prepare pose reached.', flush=True)
                 continue
             if prompt_id in self.task_descriptions:
                 break
@@ -179,8 +202,8 @@ class OliInferenceRunner(BaseInferenceRunner):
         while self._running:
             try:
                 value = input(
-                    f'Execution count [{self.default_execution_count}] '
-                    '(q to quit): ')
+                    'Number of action chunks '
+                    f'(default: {self.default_execution_count}, q to quit): ')
             except (EOFError, KeyboardInterrupt):
                 self._running = False
                 return []
@@ -225,10 +248,53 @@ class OliInferenceRunner(BaseInferenceRunner):
 
         with torch.inference_mode():
             try:
-                while self._running:
-                    self._run_episode(initial_instruction)
+                if self.interactive:
+                    while self._running:
+                        self._run_episode(initial_instruction)
+                else:
+                    self._run_continuous()
             except _ShutdownRequested:
                 pass
+
+    def _infer_and_execute_chunk(self, instruction):
+        """Predict and execute one action chunk, preserving its context."""
+        self._action_ctx = SimpleNamespace(instruction=instruction)
+        inputs = self._preprocess(instruction)
+
+        with torch.autocast(
+                'cuda',
+                dtype=self.mixed_precision_dtype,
+                enabled=(self.enable_mixed_precision
+                         and not self._use_remote)):
+            raw_action = self._predict_action(inputs)
+
+        actions = self._postprocess_actions(raw_action)
+        sent_steps = self._execute_actions(actions, None)
+        self._prev_ctx = self._action_ctx
+        return sent_steps
+
+    def _run_continuous(self):
+        """Run the default prompt continuously without reading stdin."""
+        prompt_id = self.default_prompt_id
+        instruction = self._get_task_description(prompt_id)
+        self._selected_prompt_id = prompt_id
+        self._prev_ctx = None
+        published_steps = 0
+        print(
+            f'[continuous] prompt_id={prompt_id} '
+            f'description={instruction!r}',
+            flush=True)
+
+        while self._running:
+            if (self.max_publish_step
+                    and published_steps >= self.max_publish_step):
+                break
+            sent_steps = self._infer_and_execute_chunk(instruction)
+            published_steps += sent_steps
+            print(
+                f'[continuous] prompt_id={prompt_id} '
+                f'published_steps={sent_steps} total_steps={published_steps}',
+                flush=True)
 
     def _run_episode(self, default_instruction):
         """Execute the selected prompt for the requested chunk count."""
@@ -237,22 +303,16 @@ class OliInferenceRunner(BaseInferenceRunner):
         published_steps = 0
 
         for execution_index, instruction in enumerate(instructions, start=1):
-            if not self._running or published_steps >= self.max_publish_step:
+            if (not self._running
+                    or (self.max_publish_step
+                        and published_steps >= self.max_publish_step)):
                 break
-            self._action_ctx = SimpleNamespace()
-            self._action_ctx.instruction = instruction
-            inputs = self._preprocess(instruction)
+            sent_steps = self._infer_and_execute_chunk(instruction)
 
-            with torch.autocast(
-                    'cuda',
-                    dtype=self.mixed_precision_dtype,
-                    enabled=(self.enable_mixed_precision
-                             and not self._use_remote)):
-                raw_action = self._predict_action(inputs)
+            if self._poll_keyboard_pause():
+                self._handle_keyboard_pause()
+                return
 
-            actions = self._postprocess_actions(raw_action)
-            sent_steps = self._execute_actions(actions, None)
-            self._prev_ctx = self._action_ctx
             published_steps += sent_steps
             print(
                 f'[execution] prompt_id={self._selected_prompt_id} '
@@ -264,7 +324,7 @@ class OliInferenceRunner(BaseInferenceRunner):
         """Poll the operator until a synchronized observation is available.
 
         Returns:
-            tuple: Camera images followed by ``state_33d``, or ``None``.
+            tuple: Camera images followed by the configured state, or ``None``.
         """
         last_wait_print = 0.0
         while self._running:
@@ -315,7 +375,7 @@ class OliInferenceRunner(BaseInferenceRunner):
         return self.observation_window[-1]
 
     def _execute_actions(self, actions: np.ndarray, rate):
-        """Send each 42-dim action to the operator with rate control."""
+        """Send each whole-body action to the operator with rate control."""
         del rate
         if self.disable_puppet_arm:
             return 0
@@ -331,16 +391,17 @@ class OliInferenceRunner(BaseInferenceRunner):
         return sent_steps
 
     def _move_to_prepare_pose(self):
-        """Smoothly restore the configured 33-dim Oli initial state."""
-        if self.initial_state is None:
-            raise RuntimeError('No Oli initial_state is configured')
+        """Smoothly move to the configured Oli prepare pose."""
+        if self.prepare_pose is None:
+            raise RuntimeError('No Oli prepare_pose is configured')
         if self.disable_puppet_arm:
             print(
-                '[reset] disable_puppet_arm=True; reset not sent.', flush=True)
-            return self.initial_state.copy()
+                '[prepare] disable_puppet_arm=True; command not sent.',
+                flush=True)
+            return self.prepare_pose.copy()
         target = self.ros_operator.gohome(
-            self.initial_state,
-            duration_sec=self.reset_duration_sec,
+            self.prepare_pose,
+            duration_sec=self.prepare_pose_duration_sec,
             publish_rate=self.publish_rate,
             running_flag_fn=lambda: self._running)
         self.observation_window = None

--- a/fluxvla/engines/runners/oli_rtc_inference_runner.py
+++ b/fluxvla/engines/runners/oli_rtc_inference_runner.py
@@ -322,6 +322,13 @@ class OliRTCInferenceRunner(OliInferenceRunner):
 
     def run(self, initial_instruction='pour water into the cup'):
         overwatch.info('Starting Oli RTC inference runner')
+        if not self.interactive:
+            prompt_id = self.default_prompt_id
+            instruction = self._get_task_description(prompt_id)
+            self._selected_prompt_id = prompt_id
+            self._prev_ctx = None
+            self._run_rtc_instruction(instruction, chunk_count=None)
+            return
         while self._running:
             self._run_episode(initial_instruction)
 
@@ -333,8 +340,8 @@ class OliRTCInferenceRunner(OliInferenceRunner):
         self._run_rtc_instruction(
             instruction=instructions[0], chunk_count=len(instructions))
 
-    def _run_rtc_instruction(self, instruction: str, chunk_count: int):
-        if chunk_count <= 0:
+    def _run_rtc_instruction(self, instruction: str, chunk_count: int | None):
+        if chunk_count is not None and chunk_count <= 0:
             return
 
         scheduler = self._make_scheduler()
@@ -357,14 +364,26 @@ class OliRTCInferenceRunner(OliInferenceRunner):
             name='OliRTCActor')
         producer.start()
         actor.start()
+        chunk_label = 'continuous' if chunk_count is None else str(chunk_count)
         overwatch.info(
-            f'Started Oli RTC producer/actor for {chunk_count} chunk(s)')
+            f'Started Oli RTC producer/actor for {chunk_label} chunk(s)')
 
-        horizon = self.execute_horizon or self.action_chunk
-        timeout = chunk_count * horizon * self._dt + 30.0
-        deadline = time.monotonic() + timeout
+        if chunk_count is None:
+            timeout = None
+            deadline = None
+        else:
+            horizon = self.execute_horizon or self.action_chunk
+            timeout = chunk_count * horizon * self._dt + 30.0
+            deadline = time.monotonic() + timeout
+        pause_requested = False
+        timed_out = False
         while self._running and (producer.is_alive() or actor.is_alive()):
-            if time.monotonic() >= deadline:
+            if self.interactive and self._poll_keyboard_pause():
+                pause_requested = True
+                stop_event.set()
+                break
+            if deadline is not None and time.monotonic() >= deadline:
+                timed_out = True
                 overwatch.error(
                     f'Oli RTC execution timed out after {timeout:.1f}s')
                 stop_event.set()
@@ -373,18 +392,28 @@ class OliRTCInferenceRunner(OliInferenceRunner):
 
         if not self._running:
             stop_event.set()
-        producer.join(timeout=2.0)
-        actor.join(timeout=2.0)
+        if pause_requested or timed_out or not self._running:
+            # Inference itself is not cancellable. Wait for both workers to
+            # observe stop_event before returning, otherwise a resumed episode
+            # could use the model concurrently with the old producer.
+            while producer.is_alive() or actor.is_alive():
+                producer.join(timeout=0.1)
+                actor.join(timeout=0.1)
+        else:
+            producer.join(timeout=2.0)
+            actor.join(timeout=2.0)
         self._rtc_stop_event = None
+        if pause_requested and self._running:
+            self._handle_keyboard_pause()
 
-    def _producer_loop(self, instruction: str, chunk_count: int,
+    def _producer_loop(self, instruction: str, chunk_count: int | None,
                        scheduler: OliRTCChunkScheduler, stop_event: Event,
                        producer_done: Event):
         committed_chunks = 0
         next_chunk_id = 0
         try:
-            while (self._running and not stop_event.is_set()
-                   and committed_chunks < chunk_count):
+            while (self._running and not stop_event.is_set() and
+                   (chunk_count is None or committed_chunks < chunk_count)):
                 request = scheduler.prepare_inference_request(
                     use_rtc=self._rtc_enabled())
                 if request is None:
@@ -411,8 +440,10 @@ class OliRTCInferenceRunner(OliInferenceRunner):
                         committed_chunks += 1
                         self._prev_ctx = self._action_ctx
                         self._last_rtc_chunk_count = committed_chunks
-                        overwatch.info(f'[OliRTC] committed chunk '
-                                       f'{committed_chunks}/{chunk_count} '
+                        progress = (
+                            str(committed_chunks) if chunk_count is None else
+                            f'{committed_chunks}/{chunk_count}')
+                        overwatch.info(f'[OliRTC] committed chunk {progress} '
                                        f'prefix_len={request.prefix_len}')
                     else:
                         debug = scheduler.last_commit_debug()
@@ -470,7 +501,7 @@ class OliRTCInferenceRunner(OliInferenceRunner):
 
     @staticmethod
     def _raw_action_to_numpy(raw_action) -> np.ndarray:
-        raw_np = raw_action.detach().cpu().numpy()
+        raw_np = raw_action.float().detach().cpu().numpy()
         if raw_np.ndim >= 3 and raw_np.shape[0] == 1:
             raw_np = raw_np[0]
         return raw_np


### PR DESCRIPTION
## Summary

Improve the Oli inference path while preserving compatibility with existing 33-state/42-action checkpoints.

- Add configurable hand representations:
  - `binary`: 2 open/close values.
  - `finger`: 12 independent BrainCo finger values over MROS, using 43-dimensional states and 52-dimensional actions.
- Preserve configurable finger force levels when publishing hand commands.
- Add explicit interactive and continuous non-interactive execution modes.
- Add chunk-boundary keyboard pause support with inference-history reset.
- Add configurable prepare-pose handling for both hand representations.
- Apply continuous execution and safe pause behavior to Oli RTC inference.
- Ensure RTC workers terminate before resuming, avoiding concurrent model access.
- Allow inference datasets to select normalization statistics by name instead of assuming `private`.
- Convert model outputs to float before NumPy conversion for dtype compatibility.
- Update the Oli inference documentation.

## Scope

This PR contains inference-side changes only. It does not add training configurations or modify model architectures.

## Compatibility

The default `hand_mode='binary'` retains the existing 33-dimensional state and 42-dimensional action behavior.

Full 12-finger control is opt-in with `hand_mode='finger'` and requires the MROS backend.