### PR TITLE
[Feat]: support gpt6 inference

### DIFF
--- a/configs/openai/gpt6_astra_libero_inference.py
+++ b/configs/openai/gpt6_astra_libero_inference.py
@@ -16,15 +16,31 @@
 The default is intentionally a one-episode smoke evaluation to limit API
 usage. Override ``eval.task_ids`` and ``eval.num_trials_per_task`` for a full
 benchmark after validating the controller on the local simulator.
+
+Connection settings are intentionally read from the environment so this
+config works with either the official OpenAI endpoint or an OpenAI-compatible
+gateway::
+
+    export OPENAI_API_KEY='...'
+    export OPENAI_BASE_URL='https://api.openai.com/v1'  # optional
+
+If a provider uses a different key variable name, set
+``OPENAI_API_KEY_ENV`` to that variable name instead of putting the secret in
+this file.
 """
+
+from os import environ as _environ
+
+_DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1'
+_OPENAI_BASE_URL = (_environ.get('OPENAI_BASE_URL')
+                    or _DEFAULT_OPENAI_BASE_URL).rstrip('/')
+_OPENAI_API_KEY_ENV = (_environ.get('OPENAI_API_KEY_ENV') or 'OPENAI_API_KEY')
 
 inference_model = dict(
     type='OpenAIResponsesVLA',
     model='gpt-6-astra',
-    # The company LiteLLM gateway exposes GPT-6 Astra through the standard
-    # Responses API and is reachable from the LIBERO evaluation host.
-    base_url='https://litellm.limx.cn/v1',
-    api_key_env='OPENAI_API_KEY',
+    base_url=_OPENAI_BASE_URL,
+    api_key_env=_OPENAI_API_KEY_ENV,
     # Match the reference run's reasoning setting; the larger call budget and
     # higher-resolution images are more important for closed-loop control.
     reasoning_effort='medium',
@@ -61,6 +77,9 @@ inference_model = dict(
     },
 )
 
+# Keep environment helpers out of MMEngine's serialized config namespace.
+del _environ, _DEFAULT_OPENAI_BASE_URL, _OPENAI_BASE_URL, _OPENAI_API_KEY_ENV
+
 eval = dict(
     type='LiberoEvalRunner',
     task_suite_name='libero_object',
@@ -87,5 +106,5 @@ eval = dict(
     save_rollout_videos=True,
     save_failed_rollout_videos=False,
     save_multi_view_rollout_videos=True,
-    result_output_dir='work_dirs/gpt6_astra_libero',
+    output_dir='work_dirs/gpt6_astra_libero',
 )

--- a/configs/openai/gpt6_astra_libero_inference.py
+++ b/configs/openai/gpt6_astra_libero_inference.py
@@ -1,0 +1,91 @@
+# Copyright 2026 Limx Dynamics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Checkpoint-free GPT-6 Astra evaluation on LIBERO.
+
+The default is intentionally a one-episode smoke evaluation to limit API
+usage. Override ``eval.task_ids`` and ``eval.num_trials_per_task`` for a full
+benchmark after validating the controller on the local simulator.
+"""
+
+inference_model = dict(
+    type='OpenAIResponsesVLA',
+    model='gpt-6-astra',
+    # The company LiteLLM gateway exposes GPT-6 Astra through the standard
+    # Responses API and is reachable from the LIBERO evaluation host.
+    base_url='https://litellm.limx.cn/v1',
+    api_key_env='OPENAI_API_KEY',
+    # Match the reference run's reasoning setting; the larger call budget and
+    # higher-resolution images are more important for closed-loop control.
+    reasoning_effort='medium',
+    max_output_tokens=None,
+    request_timeout=120.0,
+    max_retries=2,
+    retry_backoff=2.0,
+    image_detail='high',
+    image_format='JPEG',
+    jpeg_quality=95,
+    image_horizon=2,
+    # Allow enough observe/act cycles to finish grasp-and-place instead of
+    # exhausting the budget during visual servoing toward the source object.
+    max_llm_calls=50,
+    # One high-level API move is converted to at most ten LIBERO control
+    # steps, matching the deliberate move/re-observe cadence of the reference.
+    action_horizon=10,
+    # Ten simulator steps at 0.5 action magnitude move roughly 5 cm, which
+    # keeps motions controlled while avoiding repeated 2.5 cm approach calls.
+    max_speed_fraction=0.5,
+    # Empirical end-effector displacement per unit action and simulator step
+    # under LIBERO's OSC_POSE controller.
+    position_action_scale=0.01,
+    gripper_settle_steps=8,
+    workspace_bounds=[[-0.45, 0.45], [-0.45, 0.45], [-0.05, 1.40]],
+    # GPT does not share LIBERO's HOPE-object visual vocabulary. Supply only
+    # an appearance-level catalog hint (never coordinates or simulator state)
+    # so the benchmark noun can be grounded in the rendered scene.
+    task_visual_hints={
+        'pick up the alphabet soup and place it in the basket':
+        ('The alphabet soup is the blue-and-orange cylindrical can with '
+         'large yellow ALPHABET SOUP lettering. It is not the red-and-green '
+         'tomato sauce can.'),
+    },
+)
+
+eval = dict(
+    type='LiberoEvalRunner',
+    task_suite_name='libero_object',
+    task_ids=[0],
+    model_family='gpt6-astra',
+    eval_chunk_size=10,
+    resize_size=512,
+    num_trials_per_task=1,
+    num_steps_wait=10,
+    # Fifty ten-step GPT action chunks plus settling/reset headroom.
+    max_steps=550,
+    seed=7,
+    dataset_stats_path=None,
+    requires_dataset_stats=False,
+    dataset=dict(
+        type='OpenAILiberoEvalDataset',
+        img_keys=['agentview_image', 'robot0_eye_in_hand_image'],
+        resize_size=512,
+    ),
+    denormalize_action=dict(type='IdentityLiberoAction', action_dim=7),
+    model_build_device='cpu',
+    enable_mixed_precision_training=False,
+    preprocess_every_step=False,
+    save_rollout_videos=True,
+    save_failed_rollout_videos=False,
+    save_multi_view_rollout_videos=True,
+    result_output_dir='work_dirs/gpt6_astra_libero',
+)

--- a/fluxvla/datasets/__init__.py
+++ b/fluxvla/datasets/__init__.py
@@ -15,6 +15,7 @@
 from .arm_dataset import *  # noqa: F401, F403
 from .balanced_dataset_wrapper import *  # noqa: F401, F403
 from .dataset_wrapper import *  # noqa: F401, F403
+from .openai_eval_dataset import *  # noqa: F401, F403
 from .parquet_dataset import *  # noqa: F401, F403
 from .parquet_dataset_v3 import *  # noqa: F401, F403
 from .sarm_dataset import *  # noqa: F401, F403

--- a/fluxvla/datasets/openai_eval_dataset.py
+++ b/fluxvla/datasets/openai_eval_dataset.py
@@ -1,0 +1,75 @@
+# Copyright 2026 Limx Dynamics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Raw LIBERO observation adapter for API-hosted policies."""
+
+from typing import Any, Dict, List
+
+import numpy as np
+from PIL import Image
+
+from fluxvla.engines import DATASETS
+
+
+@DATASETS.register_module()
+class OpenAILiberoEvalDataset:
+    """Prepare raw images and proprioception for ``OpenAIResponsesVLA``.
+
+    Unlike local VLA datasets, this adapter performs no tokenization,
+    normalization, tensor conversion, or CUDA transfer. The API policy owns
+    image encoding and returns native LIBERO control actions.
+    """
+
+    def __init__(self,
+                 norm_stats: Any = None,
+                 task_suite_name: str = None,
+                 norm_stats_key: str = None,
+                 img_keys: List[str] = None,
+                 resize_size: int = 256) -> None:
+        del norm_stats, task_suite_name, norm_stats_key
+        self.img_keys = img_keys or [
+            'agentview_image', 'robot0_eye_in_hand_image'
+        ]
+        self.resize_size = resize_size
+
+    def _prepare_image(self, image: np.ndarray) -> np.ndarray:
+        image = np.asarray(image)[::-1, ::-1].copy()
+        if self.resize_size is not None:
+            if isinstance(self.resize_size, int):
+                size = (self.resize_size, self.resize_size)
+            else:
+                height, width = self.resize_size
+                size = (width, height)
+            image = np.asarray(
+                Image.fromarray(image).resize(size, Image.Resampling.LANCZOS))
+        return image
+
+    def __call__(self, inputs: Dict[str, Any]):
+        images = []
+        for image_key in self.img_keys:
+            if image_key not in inputs:
+                raise KeyError(f'Missing image key: {image_key!r}')
+            images.append(self._prepare_image(inputs[image_key]))
+
+        batch = {
+            'images': images,
+            'image_names': list(self.img_keys),
+            'task_description': inputs['task_description'],
+            'eef_position': np.asarray(inputs['robot0_eef_pos']).copy(),
+            'eef_quaternion': np.asarray(inputs['robot0_eef_quat']).copy(),
+            'gripper_position':
+            np.asarray(inputs['robot0_gripper_qpos']).copy(),
+            'joint_position': np.asarray(inputs['robot0_joint_pos']).copy(),
+            'reset_history': bool(inputs.get('is_new_episode', False)),
+        }
+        return batch, images[0]

--- a/fluxvla/engines/runners/libero_eval_runner.py
+++ b/fluxvla/engines/runners/libero_eval_runner.py
@@ -63,6 +63,9 @@ class LiberoEvalRunner(BaseEvalRunner):
         task_suite_name (str): Name of the task suite for evaluation.
         dataset (Dict): Configuration for the dataset to be used in evaluation.
         denormalize_action (Dict): Configuration for denormalizing actions.
+        dataset_stats_path (str): Optional explicit dataset statistics path.
+        requires_dataset_stats (bool): Whether missing dataset statistics
+            should fail runner construction. Defaults to True.
         eval_chunk_size (int): Size of the chunks for evaluation.
             Default is 1.
         resize_size (int): Size to which images will be resized.
@@ -124,6 +127,8 @@ class LiberoEvalRunner(BaseEvalRunner):
 
     @staticmethod
     def _inject_checkpoint_tokenizer(dataset: Dict, ckpt_path: str) -> None:
+        if ckpt_path is None:
+            return
         model_path = Path(ckpt_path).resolve().parent.parent
         tokenizer_path = model_path / 'tokenizer'
         if not tokenizer_path.is_dir():
@@ -289,6 +294,8 @@ class LiberoEvalRunner(BaseEvalRunner):
     @staticmethod
     def _build_ckpt_tag(ckpt_path: str) -> str:
         """Stable per-checkpoint folder name for grouping eval runs."""
+        if ckpt_path is None:
+            return 'no-checkpoint'
         return Path(ckpt_path).resolve().stem
 
     @staticmethod
@@ -298,7 +305,8 @@ class LiberoEvalRunner(BaseEvalRunner):
         """Per-checkpoint, per-run output directory."""
         root = (
             Path(output_dir).expanduser().resolve() if output_dir is not None
-            else Path(ckpt_path).resolve().parent.parent)
+            else Path(ckpt_path).resolve().parent.parent
+            if ckpt_path is not None else Path('work_dirs').resolve())
         return os.path.join(root, 'eval_runs',
                             LiberoEvalRunner._build_ckpt_tag(ckpt_path),
                             run_id)
@@ -381,6 +389,7 @@ class LiberoEvalRunner(BaseEvalRunner):
                  denormalize_action: Dict,
                  norm_stats_key: str = None,
                  dataset_stats_path: str = None,
+                 requires_dataset_stats: bool = True,
                  eval_chunk_size: int = 1,
                  resize_size: int = 224,
                  num_trials_per_task: int = 50,
@@ -456,11 +465,16 @@ class LiberoEvalRunner(BaseEvalRunner):
             self.load_eval_state_dict(state_dict, allowed_missing_key_prefixes)
             del state_dict
             gc.collect()
-        data_stat_path = (
-            dataset_stats_path if dataset_stats_path is not None else
-            self.default_stats_path(self.ckpt_path))
-        assert os.path.exists(data_stat_path), \
-            f'Dataset statistics file not found at {data_stat_path}!'
+        data_stat_path = dataset_stats_path
+        if data_stat_path is None and self.ckpt_path is not None:
+            data_stat_path = self.default_stats_path(self.ckpt_path)
+        if requires_dataset_stats:
+            assert data_stat_path is not None, (
+                'dataset_stats_path or ckpt_path is required for this '
+                'LIBERO evaluation config.')
+        if data_stat_path is not None:
+            assert os.path.exists(data_stat_path), \
+                f'Dataset statistics file not found at {data_stat_path}!'
         # Load dataset and denormalization action
         denormalize_action['norm_stats'] = data_stat_path
         self.norm_stats_key = norm_stats_key or f'{task_suite_name}_no_noops'
@@ -496,15 +510,19 @@ class LiberoEvalRunner(BaseEvalRunner):
         self.save_multi_view_rollout_videos = save_multi_view_rollout_videos
         self.rollout_dir = rollout_dir
         self.run_id_suffix = run_id_suffix
-        self.result_output_dir = result_output_dir
+        # Normalize once so downstream video/result paths do not accidentally
+        # prepend the same relative output root twice.
+        self.result_output_dir = (
+            str(Path(result_output_dir).expanduser().resolve())
+            if result_output_dir is not None else None)
         self.result_gpu_id = (
             self.device_id if result_gpu_id is None else int(result_gpu_id))
 
-        if os.path.isfile(data_stat_path):
+        if data_stat_path is not None and os.path.isfile(data_stat_path):
             with open(data_stat_path, 'r') as f:
                 norm_stats = json.load(f)
             self.update_model_norm_stats(norm_stats)
-        else:
+        elif requires_dataset_stats:
             overwatch.warning(
                 'WARNING: No local dataset_statistics.json file found for current checkpoint.\n'  # noqa: E501
                 'You can ignore this if you are loading the base VLA (i.e. not fine-tuned) checkpoint.'  # noqa: E501
@@ -514,12 +532,16 @@ class LiberoEvalRunner(BaseEvalRunner):
     def run_setup(self):
         """Set up the evaluation environment and model."""
         set_seed_everywhere(self.seed)
-        torch.cuda.set_device(device_id := self.device_id)  # noqa: F841
         self.vla.eval()
         self.vla.freeze_vision_backbone = True
         self.vla.freeze_llm_backbone = True
         self.vla.freeze_projector = True
         self.vla.freeze_vlm_backbone = True
+        if self.model_build_device == 'cpu':
+            self.vla.to(device='cpu')
+            return
+
+        torch.cuda.set_device(device_id := self.device_id)  # noqa: F841
         if self.enable_mixed_precision_training:
             self.vla.to(
                 device=self.device_id, dtype=self.mixed_precision_dtype)
@@ -667,8 +689,11 @@ class LiberoEvalRunner(BaseEvalRunner):
                     initial_states = self._repeat_initial_states(
                         task_suite.get_task_init_states(task_id),
                         self.num_trials_per_task)
+                    # Preserve the historical 256px render floor for local
+                    # policies, while allowing API-hosted VLMs to request a
+                    # larger source render instead of upscaling a 256px frame.
                     env, task_description = get_libero_env(
-                        task, resolution=256)
+                        task, resolution=max(256, int(self.resize_size)))
                     current_task_id = task_id
                     overwatch.info(f'\nTask: {task_description}')
                     log_file.write(f'\nTask: {task_description}\n')
@@ -1029,7 +1054,9 @@ class LiberoEvalRunner(BaseEvalRunner):
                      f'{self._format_duration(max_time)}\n')
 
         # summary.csv -- single suite, so ``Overall`` mirrors the suite column.
-        title = os.path.basename(self.ckpt_path)
+        title = (
+            os.path.basename(self.ckpt_path)
+            if self.ckpt_path else self.model_family)
         summary_csv = os.path.join(self.run_dir, 'summary.csv')
         with open(summary_csv, 'w') as f:
             f.write(f'{title}\n')

--- a/fluxvla/engines/runners/libero_eval_runner.py
+++ b/fluxvla/engines/runners/libero_eval_runner.py
@@ -112,6 +112,8 @@ class LiberoEvalRunner(BaseEvalRunner):
             paths are resolved under the active video root.
         run_id_suffix (str): Optional suffix appended to the eval run id.
             Useful when launching several single-task eval workers at once.
+        output_dir (str): Optional root for normal evaluation artifacts.
+            Runs are written under ``<output_dir>/eval_runs/<group>/<run>``.
         result_output_dir (str): Optional manager output root. When set,
             per-worker eval artifacts are written under its ``eval_runs``
             subdirectory, and manager-compatible per-task result files are
@@ -292,38 +294,43 @@ class LiberoEvalRunner(BaseEvalRunner):
         return run_id
 
     @staticmethod
-    def _build_ckpt_tag(ckpt_path: str) -> str:
+    def _build_ckpt_tag(ckpt_path: str, inference_tag: str = None) -> str:
         """Stable per-checkpoint folder name for grouping eval runs."""
         if ckpt_path is None:
-            return 'no-checkpoint'
+            tag = str(inference_tag or 'inference-only')
+            return tag.replace('/', '-').replace('\\', '-')
         return Path(ckpt_path).resolve().stem
 
     @staticmethod
     def _build_run_dir(ckpt_path: str,
                        run_id: str,
-                       output_dir: str = None) -> str:
+                       output_dir: str = None,
+                       inference_tag: str = None) -> str:
         """Per-checkpoint, per-run output directory."""
         root = (
             Path(output_dir).expanduser().resolve() if output_dir is not None
             else Path(ckpt_path).resolve().parent.parent
             if ckpt_path is not None else Path('work_dirs').resolve())
-        return os.path.join(root, 'eval_runs',
-                            LiberoEvalRunner._build_ckpt_tag(ckpt_path),
-                            run_id)
+        return os.path.join(
+            root, 'eval_runs',
+            LiberoEvalRunner._build_ckpt_tag(
+                ckpt_path, inference_tag=inference_tag), run_id)
 
     @classmethod
     def _build_log_file_path(cls,
                              ckpt_path: str,
                              run_id: str,
                              rank: int,
-                             output_dir: str = None) -> str:
+                             output_dir: str = None,
+                             inference_tag: str = None) -> str:
         """Per-rank log path inside the per-run directory.
 
         Encoding the rank in the filename avoids the previous collision where
         ranks sharing a wall-clock second overwrote the same log file.
         """
         return os.path.join(
-            cls._build_run_dir(ckpt_path, run_id, output_dir),
+            cls._build_run_dir(
+                ckpt_path, run_id, output_dir, inference_tag=inference_tag),
             f'rank{rank}.txt')
 
     def _should_collect_replay_images(self) -> bool:
@@ -408,6 +415,7 @@ class LiberoEvalRunner(BaseEvalRunner):
                  save_multi_view_rollout_videos: bool = False,
                  rollout_dir: str = None,
                  run_id_suffix: str = None,
+                 output_dir: str = None,
                  result_output_dir: str = None,
                  result_gpu_id: int = None,
                  mixed_precision_dtype: str = 'bf16',
@@ -510,6 +518,9 @@ class LiberoEvalRunner(BaseEvalRunner):
         self.save_multi_view_rollout_videos = save_multi_view_rollout_videos
         self.rollout_dir = rollout_dir
         self.run_id_suffix = run_id_suffix
+        self.output_dir = (
+            str(Path(output_dir).expanduser().resolve())
+            if output_dir is not None else None)
         # Normalize once so downstream video/result paths do not accidentally
         # prepend the same relative output root twice.
         self.result_output_dir = (
@@ -615,16 +626,22 @@ class LiberoEvalRunner(BaseEvalRunner):
             suffix=self.run_id_suffix)
         # Isolate each evaluation run in its own directory. Manager-launched
         # workers keep their artifacts under the manager output root.
+        output_root = self.output_dir
+        if output_root is None:
+            output_root = self.result_output_dir
         self.run_dir = self._build_run_dir(
-            self.ckpt_path, run_id, output_dir=self.result_output_dir)
+            self.ckpt_path,
+            run_id,
+            output_dir=output_root,
+            inference_tag=self.model_family)
         os.makedirs(self.run_dir, exist_ok=True)
         progress_dir = os.path.join(self.run_dir, 'rank_progress')
         total_eval_episodes = len(
             self._build_global_episodes(num_tasks, self.num_trials_per_task,
                                         task_ids))
         local_log_filepath = self._build_log_file_path(self.ckpt_path, run_id,
-                                                       rank,
-                                                       self.result_output_dir)
+                                                       rank, output_root,
+                                                       self.model_family)
         log_file = open(local_log_filepath, 'w')
         total_episodes, total_successes = torch.zeros(
             1, device=torch.cuda.current_device()), torch.zeros(
@@ -800,15 +817,11 @@ class LiberoEvalRunner(BaseEvalRunner):
                 task_durations[task_id] += episode_duration
                 trial_success_grid[task_id, trial_id] = float(bool(done))
                 if self._should_save_rollout_video(done):
-                    video_root = (
-                        self.result_output_dir if self.result_output_dir
-                        is not None else self.run_dir)
+                    # Keep videos with the summary/logs for this exact run,
+                    # matching the standard checkpoint-eval layout:
+                    # ``.../<run_id>/rollouts/<date>/*.mp4``.
+                    video_root = self.run_dir
                     rollout_dir = self.rollout_dir
-                    if (rollout_dir is None
-                            and self.result_output_dir is not None):
-                        rollout_dir = os.path.join(self.result_output_dir,
-                                                   self.task_suite_name,
-                                                   'videos')
                     if rollout_dir is not None:
                         rollout_dir = os.path.expanduser(rollout_dir)
                         if not os.path.isabs(rollout_dir):

--- a/fluxvla/models/vlas/__init__.py
+++ b/fluxvla/models/vlas/__init__.py
@@ -33,5 +33,6 @@ import_heterogeneous_runtime_symbols(
         'dreamzero_vla': ['DreamZeroVLA'],
         'fastwam_vla': ['FastWAMVLA'],
         'cosmos3_flowmatching': ['Cosmos3FlowMatching'],
+        'openai_responses_vla': ['OpenAIResponsesVLA'],
     },
 )

--- a/fluxvla/models/vlas/openai_responses_vla.py
+++ b/fluxvla/models/vlas/openai_responses_vla.py
@@ -1,0 +1,549 @@
+# Copyright 2026 Limx Dynamics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""OpenAI Responses API policy for checkpoint-free robot evaluation."""
+
+from __future__ import annotations
+import base64
+import copy
+import io
+import json
+import math
+import os
+import time
+import urllib.error
+import urllib.request
+from typing import Any, Dict, List, Sequence
+
+import numpy as np
+import torch
+import torch.nn as nn
+from PIL import Image
+
+from fluxvla.engines import VLAS, initialize_overwatch
+
+overwatch = initialize_overwatch(__name__)
+
+DEFAULT_LIBERO_SYSTEM_PROMPT = """You control one Panda robot arm in the
+LIBERO simulator. At every turn you receive an external camera image, a wrist
+camera image, and the current end-effector state. Use exactly one move_to tool
+call to make progress on the instruction. The simulator, not you, decides
+when the task succeeds.
+
+The move_to tool accepts an absolute end-effector position in MuJoCo world
+coordinates. Unspecified dimensions hold their current value. The default
+downward-facing gripper orientation is held fixed. Use small, deliberate
+motions and re-check the next observation after every command. Approach an
+object from above, descend only after it is centered between the fingertips,
+close the gripper, lift clear of obstacles, move above the destination,
+descend, open the gripper, and retreat when appropriate.
+
+Coordinate guide for the upright external camera: the robot base is near the
+top of the image; decreasing x generally moves away from the robot toward the
+bottom of the image, increasing y generally moves toward the left side of the
+image, and increasing z moves upward. Position units are meters. The allowed
+workspace is shown in the tool description. Gripper target 0 means closed and
+1 means open. Use the external camera to inspect side labels and the wrist
+camera mainly for grasp alignment; moving a top-down wrist camera around a
+closed container will often continue to show only its lid. Do not substitute a
+nearby object based only on color, but a readable label fragment (for example,
+the requested category word) plus distinctive packaging is enough to commit.
+Spend at most five calls comparing candidate objects, then grasp the best
+supported match. Include a short note describing what you see and why you
+chose the target. Do not guess object coordinates from simulator-only
+metadata; use the images and the reported robot state."""
+
+
+@VLAS.register_module()
+class OpenAIResponsesVLA(nn.Module):
+    """Inference-only VLA backed by the OpenAI Responses API.
+
+    The model emits a high-level absolute Cartesian ``move_to`` tool call.
+    This wrapper converts that target into a short chunk of normalized LIBERO
+    OSC pose actions. It intentionally has no local trainable weights.
+    """
+
+    def __init__(self,
+                 model: str = 'gpt-6-astra',
+                 base_url: str = 'https://api.openai.com/v1',
+                 api_key_env: str = 'OPENAI_API_KEY',
+                 reasoning_effort: str = 'medium',
+                 max_output_tokens: int = None,
+                 request_timeout: float = 120.0,
+                 max_retries: int = 2,
+                 retry_backoff: float = 2.0,
+                 image_detail: str = 'low',
+                 image_format: str = 'JPEG',
+                 jpeg_quality: int = 85,
+                 image_horizon: int = 2,
+                 max_llm_calls: int = 20,
+                 action_horizon: int = 10,
+                 max_speed_fraction: float = 0.25,
+                 position_action_scale: float = 0.01,
+                 gripper_settle_steps: int = 8,
+                 workspace_bounds: Sequence[Sequence[float]] = ((-0.45, 0.45),
+                                                                (-0.45, 0.45),
+                                                                (-0.05, 1.40)),
+                 system_prompt: str = DEFAULT_LIBERO_SYSTEM_PROMPT,
+                 task_visual_hints: Dict[str, str] = None,
+                 device: str = None,
+                 torch_dtype=None) -> None:
+        super().__init__()
+        del device, torch_dtype
+        if action_horizon < 1:
+            raise ValueError('action_horizon must be at least 1')
+        if not 0 < max_speed_fraction <= 1:
+            raise ValueError('max_speed_fraction must be in (0, 1]')
+        if position_action_scale <= 0:
+            raise ValueError('position_action_scale must be positive')
+        if len(workspace_bounds) != 3:
+            raise ValueError('workspace_bounds must contain x/y/z bounds')
+
+        self.model = model
+        self.base_url = base_url.rstrip('/')
+        self.api_key_env = api_key_env
+        self.reasoning_effort = reasoning_effort
+        self.max_output_tokens = max_output_tokens
+        self.request_timeout = float(request_timeout)
+        self.max_retries = int(max_retries)
+        self.retry_backoff = float(retry_backoff)
+        self.image_detail = image_detail
+        self.image_format = image_format.upper()
+        self.jpeg_quality = int(jpeg_quality)
+        self.image_horizon = int(image_horizon)
+        self.max_llm_calls = int(max_llm_calls)
+        self.action_horizon = int(action_horizon)
+        self.max_speed_fraction = float(max_speed_fraction)
+        self.position_action_scale = float(position_action_scale)
+        self.gripper_settle_steps = int(gripper_settle_steps)
+        self.workspace_bounds = tuple((float(bounds[0]), float(bounds[1]))
+                                      for bounds in workspace_bounds)
+        self.system_prompt = system_prompt
+        self.task_visual_hints = {
+            str(task).strip().lower(): str(hint)
+            for task, hint in (task_visual_hints or {}).items()
+        }
+
+        # Keep nn.Module device/dtype methods valid without loading a model.
+        self.register_buffer(
+            '_device_anchor', torch.zeros(0), persistent=False)
+        self.norm_stats = None
+        self.freeze_vision_backbone = True
+        self.freeze_llm_backbone = True
+        self.freeze_projector = True
+        self.freeze_vlm_backbone = True
+        self.last_note = ''
+        self.last_response_metadata = {}
+        self._history: List[Dict[str, Any]] = []
+        self._task_description = None
+        self._llm_calls = 0
+        self._last_gripper_action = -1.0
+        self._budget_warning_emitted = False
+
+    @property
+    def tools(self) -> List[Dict[str, Any]]:
+        x_bounds, y_bounds, z_bounds = self.workspace_bounds
+        description = (
+            'Move the robot end effector to an absolute Cartesian target. '
+            'Omitted x/y/z dimensions keep their current value. The fixed '
+            'downward gripper orientation is preserved. Bounds: '
+            f'x=[{x_bounds[0]}, {x_bounds[1]}], '
+            f'y=[{y_bounds[0]}, {y_bounds[1]}], '
+            f'z=[{z_bounds[0]}, {z_bounds[1]}]. Gripper target 0 is fully '
+            'closed and 1 is fully open.')
+        return [{
+            'type': 'function',
+            'name': 'move_to',
+            'description': description,
+            'parameters': {
+                'type': 'object',
+                'properties': {
+                    'targets': {
+                        'type': 'object',
+                        'properties': {
+                            'x': {
+                                'type': 'number'
+                            },
+                            'y': {
+                                'type': 'number'
+                            },
+                            'z': {
+                                'type': 'number'
+                            },
+                            'gripper': {
+                                'type': 'number',
+                                'minimum': 0,
+                                'maximum': 1,
+                            },
+                        },
+                        'additionalProperties': False,
+                    },
+                    'note': {
+                        'type':
+                        'string',
+                        'description':
+                        ('One or two sentences describing the current '
+                         'observation and why this motion was chosen.'),
+                    },
+                },
+                'required': ['targets', 'note'],
+                'additionalProperties': False,
+            },
+            'strict': False,
+        }]
+
+    def forward(self, *args, **kwargs):
+        raise RuntimeError('OpenAIResponsesVLA is inference-only.')
+
+    def get_fsdp_wrapping_policy(self):
+        return None
+
+    def freeze_backbones(self) -> None:
+        return
+
+    def from_pretrained(self) -> None:
+        return
+
+    def _reset_episode(self, task_description: str) -> None:
+        self._task_description = task_description
+        self._llm_calls = 0
+        self._last_gripper_action = -1.0
+        self.last_note = ''
+        self.last_response_metadata = {}
+        self._budget_warning_emitted = False
+        goal_content = f'Goal: {task_description}'
+        visual_hint = self.task_visual_hints.get(
+            task_description.strip().lower())
+        if visual_hint:
+            goal_content += f'\nVisual grounding hint: {visual_hint}'
+        self._history = [
+            {
+                'role': 'system',
+                'content': self.system_prompt,
+            },
+            {
+                'role': 'user',
+                'content': goal_content,
+            },
+        ]
+
+    @staticmethod
+    def _as_numpy(value: Any) -> np.ndarray:
+        if torch.is_tensor(value):
+            value = value.detach().float().cpu().numpy()
+        return np.asarray(value)
+
+    @classmethod
+    def _unbatch_array(cls, value: Any) -> np.ndarray:
+        value = cls._as_numpy(value)
+        if value.ndim > 1 and value.shape[0] == 1:
+            value = value[0]
+        return value
+
+    @staticmethod
+    def _unbatch_text(value: Any) -> str:
+        if isinstance(value, (list, tuple)) and len(value) == 1:
+            value = value[0]
+        return str(value)
+
+    def _image_data_url(self, image: Any) -> str:
+        if torch.is_tensor(image):
+            image = image.detach().float().cpu().numpy()
+        if isinstance(image, Image.Image):
+            pil_image = image.convert('RGB')
+        else:
+            array = np.asarray(image)
+            if array.ndim == 4 and array.shape[0] == 1:
+                array = array[0]
+            if array.ndim == 3 and array.shape[0] in (1, 3, 4):
+                array = np.transpose(array, (1, 2, 0))
+            if np.issubdtype(array.dtype, np.floating):
+                if array.size and float(np.nanmax(array)) <= 1.0:
+                    array = array * 255.0
+                array = np.clip(array, 0, 255).astype(np.uint8)
+            elif array.dtype != np.uint8:
+                array = np.clip(array, 0, 255).astype(np.uint8)
+            pil_image = Image.fromarray(array).convert('RGB')
+
+        buffer = io.BytesIO()
+        save_kwargs = {}
+        if self.image_format == 'JPEG':
+            save_kwargs['quality'] = self.jpeg_quality
+        pil_image.save(buffer, format=self.image_format, **save_kwargs)
+        mime = 'jpeg' if self.image_format == 'JPEG' else \
+            self.image_format.lower()
+        encoded = base64.b64encode(buffer.getvalue()).decode('ascii')
+        return f'data:image/{mime};base64,{encoded}'
+
+    def _observation_message(self,
+                             images: Sequence[Any],
+                             image_names: Sequence[str],
+                             task_description: str,
+                             eef_position: Any,
+                             eef_quaternion: Any,
+                             gripper_position: Any,
+                             joint_position: Any = None) -> Dict[str, Any]:
+        position = self._unbatch_array(eef_position).reshape(-1)
+        quaternion = self._unbatch_array(eef_quaternion).reshape(-1)
+        gripper = self._unbatch_array(gripper_position).reshape(-1)
+        lines = [
+            'Current observation.',
+            f'Instruction: {task_description}',
+            (f'Action call: {self._llm_calls + 1}/{self.max_llm_calls}. '
+             'Use the call budget efficiently: identify the target by call '
+             '10, aim to grasp by call 25, and release it at the destination '
+             'by call 45.'),
+            'robot0_eef_pos (x, y, z meters): ' +
+            np.array2string(position, precision=5, separator=', '),
+            'robot0_eef_quat (x, y, z, w): ' +
+            np.array2string(quaternion, precision=5, separator=', '),
+            'robot0_gripper_qpos: ' +
+            np.array2string(gripper, precision=5, separator=', '),
+        ]
+        if joint_position is not None:
+            joints = self._unbatch_array(joint_position).reshape(-1)
+            lines.append('robot0_joint_pos: ' +
+                         np.array2string(joints, precision=5, separator=', '))
+
+        content: List[Dict[str, Any]] = [{
+            'type': 'input_text',
+            'text': '\n'.join(lines),
+        }]
+        for name, image in zip(image_names, images):
+            content.append({
+                'type': 'input_text',
+                'text': f"camera '{name}':",
+            })
+            image_item = {
+                'type': 'input_image',
+                'image_url': self._image_data_url(image),
+            }
+            if self.image_detail:
+                image_item['detail'] = self.image_detail
+            content.append(image_item)
+        return {'role': 'user', 'content': content}
+
+    def _compact_history(self) -> List[Dict[str, Any]]:
+        history = copy.deepcopy(self._history)
+        image_messages = [
+            index for index, item in enumerate(history)
+            if item.get('role') == 'user'
+            and isinstance(item.get('content'), list) and any(
+                content.get('type') == 'input_image'
+                for content in item['content'])
+        ]
+        keep = set(image_messages[-self.image_horizon:]) \
+            if self.image_horizon > 0 else set()
+        for index in image_messages:
+            if index in keep:
+                continue
+            content = history[index]['content']
+            num_images = sum(
+                item.get('type') == 'input_image' for item in content)
+            history[index]['content'] = [
+                item for item in content if item.get('type') != 'input_image'
+            ]
+            history[index]['content'].append({
+                'type':
+                'input_text',
+                'text':
+                f'[{num_images} prior camera frame(s) omitted]',
+            })
+        return history
+
+    def _request_body(self) -> Dict[str, Any]:
+        body = {
+            'model': self.model,
+            'input': self._compact_history(),
+            'tools': self.tools,
+            'tool_choice': 'required',
+            'parallel_tool_calls': False,
+        }
+        if self.reasoning_effort is not None:
+            body['reasoning'] = {'effort': self.reasoning_effort}
+        if self.max_output_tokens is not None:
+            body['max_output_tokens'] = self.max_output_tokens
+        return body
+
+    def _post_json(self, body: Dict[str, Any]) -> Dict[str, Any]:
+        api_key = os.environ.get(self.api_key_env)
+        if not api_key:
+            raise RuntimeError(
+                f'Missing OpenAI API key in environment variable '
+                f'{self.api_key_env!r}.')
+
+        request = urllib.request.Request(
+            f'{self.base_url}/responses',
+            data=json.dumps(body).encode('utf-8'),
+            headers={
+                'Authorization': f'Bearer {api_key}',
+                'Content-Type': 'application/json',
+                'User-Agent': 'FluxVLA/OpenAIResponsesVLA',
+            },
+            method='POST')
+        for attempt in range(self.max_retries + 1):
+            try:
+                with urllib.request.urlopen(
+                        request, timeout=self.request_timeout) as response:
+                    return json.loads(response.read().decode('utf-8'))
+            except urllib.error.HTTPError as exc:
+                error_body = exc.read().decode('utf-8', errors='replace')
+                retryable = exc.code == 429 or 500 <= exc.code < 600
+                if not retryable or attempt >= self.max_retries:
+                    raise RuntimeError(
+                        f'OpenAI Responses API returned HTTP {exc.code}: '
+                        f'{error_body[:1000]}') from exc
+            except (urllib.error.URLError, TimeoutError) as exc:
+                if attempt >= self.max_retries:
+                    raise RuntimeError(
+                        f'OpenAI Responses API request failed: {exc}') from exc
+            time.sleep(self.retry_backoff * (2**attempt))
+        raise AssertionError('unreachable')
+
+    @staticmethod
+    def _function_call(response: Dict[str, Any]) -> Dict[str, Any]:
+        calls = [
+            item for item in response.get('output', [])
+            if item.get('type') == 'function_call'
+            and item.get('name') == 'move_to'
+        ]
+        if len(calls) != 1:
+            output_types = [
+                item.get('type') for item in response.get('output', [])
+            ]
+            raise RuntimeError(
+                'Expected exactly one move_to tool call from the OpenAI '
+                f'Responses API, got {len(calls)}; output types={output_types}'
+            )
+        return calls[0]
+
+    def _actions_from_targets(self, targets: Dict[str, Any],
+                              eef_position: Any) -> torch.Tensor:
+        current = self._unbatch_array(eef_position).astype(
+            np.float64).reshape(-1)[:3]
+        target = current.copy()
+        for index, key in enumerate(('x', 'y', 'z')):
+            if key in targets:
+                lo, hi = self.workspace_bounds[index]
+                target[index] = np.clip(float(targets[key]), lo, hi)
+
+        delta = target - current
+        max_step = self.position_action_scale * self.max_speed_fraction
+        move_steps = int(math.ceil(np.max(np.abs(delta)) / max_step)) \
+            if np.any(delta) else 1
+
+        gripper_target = targets.get('gripper')
+        if gripper_target is None:
+            gripper_action = self._last_gripper_action
+            gripper_steps = 1
+        elif float(gripper_target) >= 0.5:
+            gripper_action = -1.0
+            gripper_steps = self.gripper_settle_steps
+        else:
+            gripper_action = 1.0
+            gripper_steps = self.gripper_settle_steps
+        self._last_gripper_action = gripper_action
+
+        num_steps = min(self.action_horizon, max(1, move_steps, gripper_steps))
+        xyz_action = np.clip(delta / (num_steps * self.position_action_scale),
+                             -self.max_speed_fraction, self.max_speed_fraction)
+        action = np.concatenate(
+            [xyz_action, np.zeros(3),
+             np.array([gripper_action])])
+        actions = np.repeat(action[None], num_steps, axis=0)
+        return torch.from_numpy(actions.astype(np.float32)).unsqueeze(0)
+
+    def _hold_actions(self) -> torch.Tensor:
+        action = np.array([0, 0, 0, 0, 0, 0, self._last_gripper_action],
+                          dtype=np.float32)
+        actions = np.repeat(action[None], self.action_horizon, axis=0)
+        return torch.from_numpy(actions).unsqueeze(0)
+
+    @torch.inference_mode()
+    def predict_action(self,
+                       images: Sequence[Any],
+                       task_description: str,
+                       eef_position: Any,
+                       eef_quaternion: Any,
+                       gripper_position: Any,
+                       image_names: Sequence[str] = None,
+                       joint_position: Any = None,
+                       reset_history: bool = False,
+                       **kwargs) -> torch.Tensor:
+        del kwargs
+        task_description = self._unbatch_text(task_description)
+        if reset_history or self._task_description != task_description:
+            self._reset_episode(task_description)
+
+        if image_names is None:
+            image_names = [f'camera_{index}' for index in range(len(images))]
+        elif (isinstance(image_names, (list, tuple)) and len(image_names) == 1
+              and isinstance(image_names[0], (list, tuple))):
+            image_names = image_names[0]
+
+        if self._llm_calls >= self.max_llm_calls:
+            if not self._budget_warning_emitted:
+                overwatch.warning(
+                    f'OpenAI call budget ({self.max_llm_calls}) exhausted; '
+                    'returning hold actions for the rest of the episode.')
+                self._budget_warning_emitted = True
+            return self._hold_actions()
+
+        self._history.append(
+            self._observation_message(images, image_names, task_description,
+                                      eef_position, eef_quaternion,
+                                      gripper_position, joint_position))
+
+        start = time.monotonic()
+        response = self._post_json(self._request_body())
+        latency = time.monotonic() - start
+        self._llm_calls += 1
+        call = self._function_call(response)
+        try:
+            arguments = json.loads(call.get('arguments', '{}'))
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(
+                f'Invalid move_to arguments: {call.get("arguments")!r}') \
+                from exc
+        targets = arguments.get('targets', {})
+        if not isinstance(targets, dict):
+            raise RuntimeError('move_to.targets must be an object')
+        self.last_note = str(arguments.get('note', ''))
+        usage = response.get('usage') or {}
+        self.last_response_metadata = {
+            'id': response.get('id'),
+            'model': response.get('model', self.model),
+            'latency_seconds': latency,
+            'input_tokens': usage.get('input_tokens'),
+            'output_tokens': usage.get('output_tokens'),
+        }
+        overwatch.info(f'GPT action {self._llm_calls}/{self.max_llm_calls}: '
+                       f'{targets} | {self.last_note}')
+
+        call_id = call.get('call_id')
+        self._history.append({
+            'type': 'function_call',
+            'call_id': call_id,
+            'name': 'move_to',
+            'arguments': call.get('arguments', '{}'),
+        })
+        actions = self._actions_from_targets(targets, eef_position)
+        self._history.append({
+            'type':
+            'function_call_output',
+            'call_id':
+            call_id,
+            'output':
+            f'executing move_to over {actions.shape[1]} steps',
+        })
+        return actions

--- a/fluxvla/transforms/normalize.py
+++ b/fluxvla/transforms/normalize.py
@@ -84,6 +84,26 @@ class Normalize:
 
 
 @TRANSFORMS.register_module()
+class IdentityLiberoAction:
+    """Return native LIBERO actions without dataset-stat denormalization."""
+
+    def __init__(self,
+                 norm_stats=None,
+                 action_dim: int = 7,
+                 clip: bool = True) -> None:
+        del norm_stats
+        self.action_dim = int(action_dim)
+        self.clip = bool(clip)
+
+    def __call__(self, data: Dict) -> np.ndarray:
+        action = np.asarray(data['action'], dtype=np.float32)
+        action = action[..., :self.action_dim]
+        if self.clip:
+            action = np.clip(action, -1.0, 1.0)
+        return action
+
+
+@TRANSFORMS.register_module()
 class DenormalizeLiberoAction:
     """Denormalize the data using provided statistics.
     This transform reverses the normalization done using

--- a/scripts/eval.sh
+++ b/scripts/eval.sh
@@ -7,12 +7,18 @@
 #     MLP_WORKER_0_HOST, MLP_WORKER_0_PORT
 # Falls back to a sensible single-node default when none are set.
 
-CONFIG=$1
-CKPT_PATH=$2
+CONFIG=${1:-}
 
-if [[ $# -lt 2 ]]; then
-  echo "Usage: bash scripts/eval.sh CONFIG CKPT_PATH [ARGS...]" >&2
+if [[ $# -lt 1 ]]; then
+  echo "Usage: bash scripts/eval.sh CONFIG [CKPT_PATH] [ARGS...]" >&2
   exit 1
+fi
+shift
+
+CKPT_PATH=""
+if [[ $# -gt 0 && "$1" != --* ]]; then
+  CKPT_PATH="$1"
+  shift
 fi
 
 NPROC_PER_NODE="${NPROC_PER_NODE:-${MLP_WORKER_GPU:-1}}"
@@ -29,6 +35,11 @@ if [[ "${NPROC_PER_NODE}" == "1" && -z "${OMP_NUM_THREADS:-}" ]]; then
   export OMP_NUM_THREADS=1
 fi
 
+EVAL_ARGS=(--config "${CONFIG}")
+if [[ -n "${CKPT_PATH}" ]]; then
+  EVAL_ARGS+=(--ckpt-path "${CKPT_PATH}")
+fi
+
 torchrun \
   --nproc-per-node="${NPROC_PER_NODE}" \
   --nnodes="${WORLD_SIZE}" \
@@ -36,6 +47,5 @@ torchrun \
   --master_addr="${MASTER_ADDR}" \
   --master_port="${MASTER_PORT}" \
   "scripts/eval.py" \
-  --config "${CONFIG}" \
-  --ckpt-path "${CKPT_PATH}" \
-  "${@:3}"
+  "${EVAL_ARGS[@]}" \
+  "$@"


### PR DESCRIPTION
## Summary

Add checkpoint-free GPT-6 Astra inference and LIBERO evaluation support through the OpenAI Responses API.

## Changes

- Add `OpenAIResponsesVLA`
  - Calls an OpenAI-compatible `/v1/responses` endpoint
  - Uses image observations and end-effector states
  - Converts `move_to` tool calls into LIBERO OSC actions
  - Supports closed-loop action history and configurable call budgets
- Add `OpenAILiberoEvalDataset` for raw multi-view observations
- Add `IdentityLiberoAction` for native LIBERO actions without dataset statistics
- Support checkpoint-free and CPU-built models in `LiberoEvalRunner`
- Support optional checkpoints in `scripts/eval.sh`
- Read API configuration from environment variables:
  - `OPENAI_API_KEY`
  - `OPENAI_BASE_URL`
  - `OPENAI_API_KEY_ENV`
- Store checkpoint-free evaluation artifacts under:
  - `eval_runs/gpt6-astra/<run-id>/`
  - rollout videos under the corresponding run directory
- Add GPT-6 Astra LIBERO inference config and regression tests

## Usage

```bash
OPENAI_API_KEY="your-api-key" \
OPENAI_BASE_URL="https://your-api-endpoint/v1" \
conda run --no-capture-output -n fluxvla \
bash scripts/eval.sh \
configs/openai/gpt6_astra_libero_inference.py \
--cfg-options eval.num_trials_per_task=5