### PR TITLE
[Enhance]: Add robocasa gpt6

### DIFF
--- a/configs/openai/gpt6_astra_libero_10_inference.py
+++ b/configs/openai/gpt6_astra_libero_10_inference.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Checkpoint-free GPT-6 Astra smoke evaluation on LIBERO-10."""
+"""Checkpoint-free GPT-6 Astra full-suite evaluation on LIBERO-10."""
 
 _base_ = './gpt6_astra_libero_inference.py'
 
@@ -19,6 +19,6 @@ inference_model = dict(task_visual_hints=dict(_delete_=True))
 
 eval = dict(
     task_suite_name='libero_10',
-    task_ids=[0],
+    task_ids=None,
     output_dir='work_dirs/gpt6_astra_libero_10',
 )

--- a/configs/openai/gpt6_astra_libero_10_inference.py
+++ b/configs/openai/gpt6_astra_libero_10_inference.py
@@ -1,0 +1,24 @@
+# Copyright 2026 Limx Dynamics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Checkpoint-free GPT-6 Astra smoke evaluation on LIBERO-10."""
+
+_base_ = './gpt6_astra_libero_inference.py'
+
+inference_model = dict(task_visual_hints=dict(_delete_=True))
+
+eval = dict(
+    task_suite_name='libero_10',
+    task_ids=[0],
+    output_dir='work_dirs/gpt6_astra_libero_10',
+)

--- a/configs/openai/gpt6_astra_libero_goal_inference.py
+++ b/configs/openai/gpt6_astra_libero_goal_inference.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Checkpoint-free GPT-6 Astra smoke evaluation on LIBERO-Goal."""
+"""Checkpoint-free GPT-6 Astra full-suite evaluation on LIBERO-Goal."""
 
 _base_ = './gpt6_astra_libero_inference.py'
 
@@ -19,6 +19,6 @@ inference_model = dict(task_visual_hints=dict(_delete_=True))
 
 eval = dict(
     task_suite_name='libero_goal',
-    task_ids=[0],
+    task_ids=None,
     output_dir='work_dirs/gpt6_astra_libero_goal',
 )

--- a/configs/openai/gpt6_astra_libero_goal_inference.py
+++ b/configs/openai/gpt6_astra_libero_goal_inference.py
@@ -1,0 +1,24 @@
+# Copyright 2026 Limx Dynamics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Checkpoint-free GPT-6 Astra smoke evaluation on LIBERO-Goal."""
+
+_base_ = './gpt6_astra_libero_inference.py'
+
+inference_model = dict(task_visual_hints=dict(_delete_=True))
+
+eval = dict(
+    task_suite_name='libero_goal',
+    task_ids=[0],
+    output_dir='work_dirs/gpt6_astra_libero_goal',
+)

--- a/configs/openai/gpt6_astra_libero_inference.py
+++ b/configs/openai/gpt6_astra_libero_inference.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 """Checkpoint-free GPT-6 Astra evaluation on LIBERO.
 
-The default is intentionally a one-episode smoke evaluation to limit API
-usage. Override ``eval.task_ids`` and ``eval.num_trials_per_task`` for a full
-benchmark after validating the controller on the local simulator.
+The default evaluates every task in the suite once. Override
+``eval.num_trials_per_task`` to increase the number of episodes per task.
 
 Connection settings are intentionally read from the environment so this
 config works with either the official OpenAI endpoint or an OpenAI-compatible
@@ -83,7 +82,7 @@ del _environ, _DEFAULT_OPENAI_BASE_URL, _OPENAI_BASE_URL, _OPENAI_API_KEY_ENV
 eval = dict(
     type='LiberoEvalRunner',
     task_suite_name='libero_object',
-    task_ids=[0],
+    task_ids=None,
     model_family='gpt6-astra',
     eval_chunk_size=10,
     resize_size=512,

--- a/configs/openai/gpt6_astra_libero_inference.py
+++ b/configs/openai/gpt6_astra_libero_inference.py
@@ -63,6 +63,12 @@ inference_model = dict(
     # Empirical end-effector displacement per unit action and simulator step
     # under LIBERO's OSC_POSE controller.
     position_action_scale=0.01,
+    # Empirical angular displacement (radians) per unit action / sim step,
+    # not OSC's raw 0.5-radian goal offset. rotation_delta is the total
+    # WORLD-frame axis-angle increment requested for one GPT call. Limit
+    # rotation independently from translation (~0.25 rad / ten-step chunk).
+    rotation_action_scale=0.1,
+    max_rotation_speed_fraction=0.25,
     gripper_settle_steps=8,
     workspace_bounds=[[-0.45, 0.45], [-0.45, 0.45], [-0.05, 1.40]],
     # GPT does not share LIBERO's HOPE-object visual vocabulary. Supply only

--- a/configs/openai/gpt6_astra_libero_object_inference.py
+++ b/configs/openai/gpt6_astra_libero_object_inference.py
@@ -1,0 +1,22 @@
+# Copyright 2026 Limx Dynamics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Checkpoint-free GPT-6 Astra smoke evaluation on LIBERO-Object."""
+
+_base_ = './gpt6_astra_libero_inference.py'
+
+eval = dict(
+    task_suite_name='libero_object',
+    task_ids=[0],
+    output_dir='work_dirs/gpt6_astra_libero_object',
+)

--- a/configs/openai/gpt6_astra_libero_object_inference.py
+++ b/configs/openai/gpt6_astra_libero_object_inference.py
@@ -11,12 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Checkpoint-free GPT-6 Astra smoke evaluation on LIBERO-Object."""
+"""Checkpoint-free GPT-6 Astra full-suite evaluation on LIBERO-Object."""
 
 _base_ = './gpt6_astra_libero_inference.py'
 
 eval = dict(
     task_suite_name='libero_object',
-    task_ids=[0],
+    task_ids=None,
     output_dir='work_dirs/gpt6_astra_libero_object',
 )

--- a/configs/openai/gpt6_astra_libero_spatial_inference.py
+++ b/configs/openai/gpt6_astra_libero_spatial_inference.py
@@ -1,0 +1,24 @@
+# Copyright 2026 Limx Dynamics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Checkpoint-free GPT-6 Astra smoke evaluation on LIBERO-Spatial."""
+
+_base_ = './gpt6_astra_libero_inference.py'
+
+inference_model = dict(task_visual_hints=dict(_delete_=True))
+
+eval = dict(
+    task_suite_name='libero_spatial',
+    task_ids=[0],
+    output_dir='work_dirs/gpt6_astra_libero_spatial',
+)

--- a/configs/openai/gpt6_astra_libero_spatial_inference.py
+++ b/configs/openai/gpt6_astra_libero_spatial_inference.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Checkpoint-free GPT-6 Astra smoke evaluation on LIBERO-Spatial."""
+"""Checkpoint-free GPT-6 Astra full-suite evaluation on LIBERO-Spatial."""
 
 _base_ = './gpt6_astra_libero_inference.py'
 
@@ -19,6 +19,6 @@ inference_model = dict(task_visual_hints=dict(_delete_=True))
 
 eval = dict(
     task_suite_name='libero_spatial',
-    task_ids=[0],
+    task_ids=None,
     output_dir='work_dirs/gpt6_astra_libero_spatial',
 )

--- a/configs/openai/gpt6_astra_robocasa_inference.py
+++ b/configs/openai/gpt6_astra_robocasa_inference.py
@@ -11,11 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Checkpoint-free GPT-6 Astra smoke evaluation on RoboCasa GR1.
+"""Checkpoint-free GPT-6 Astra full-suite evaluation on RoboCasa GR1.
 
-The config contains all 24 standard RoboCasa tasks but evaluates task 0 for
-one episode by default to control API cost. Set ``eval.task_ids=None`` and
-``eval.num_trials_per_task`` to run the complete benchmark.
+The config evaluates all 24 standard RoboCasa tasks once by default. Override
+``eval.num_trials_per_task`` to increase the number of episodes per task.
 
 Connection settings are read from the environment::
 
@@ -93,7 +92,7 @@ eval = dict(
         for task_name in _ROBOCASA_TASK_NAMES
     ],
     total_tasks=len(_ROBOCASA_TASK_NAMES),
-    task_ids=[0],
+    task_ids=None,
     eval_chunk_size=8,
     max_episode_steps=720,
     num_trials_per_task=1,

--- a/configs/openai/gpt6_astra_robocasa_inference.py
+++ b/configs/openai/gpt6_astra_robocasa_inference.py
@@ -1,0 +1,128 @@
+# Copyright 2026 Limx Dynamics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Checkpoint-free GPT-6 Astra smoke evaluation on RoboCasa GR1.
+
+The config contains all 24 standard RoboCasa tasks but evaluates task 0 for
+one episode by default to control API cost. Set ``eval.task_ids=None`` and
+``eval.num_trials_per_task`` to run the complete benchmark.
+
+Connection settings are read from the environment::
+
+    export OPENAI_API_KEY='...'
+    export OPENAI_BASE_URL='https://api.openai.com/v1'  # optional
+
+Set ``OPENAI_API_KEY_ENV`` when an OpenAI-compatible provider exposes its key
+under another environment-variable name.
+"""
+
+from os import environ as _environ
+
+_DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1'
+_OPENAI_BASE_URL = (_environ.get('OPENAI_BASE_URL')
+                    or _DEFAULT_OPENAI_BASE_URL).rstrip('/')
+_OPENAI_API_KEY_ENV = (_environ.get('OPENAI_API_KEY_ENV') or 'OPENAI_API_KEY')
+
+inference_model = dict(
+    type='OpenAIResponsesRobocasaVLA',
+    model='gpt-6-astra',
+    base_url=_OPENAI_BASE_URL,
+    api_key_env=_OPENAI_API_KEY_ENV,
+    reasoning_effort='medium',
+    max_output_tokens=None,
+    request_timeout=120.0,
+    max_retries=2,
+    retry_backoff=2.0,
+    image_detail='high',
+    image_format='JPEG',
+    jpeg_quality=95,
+    image_horizon=2,
+    # 90 calls x 8 environment steps covers RoboCasa's 720-step horizon.
+    max_llm_calls=90,
+    action_horizon=8,
+    max_arm_joint_delta=0.12,
+    max_waist_joint_delta=0.05,
+)
+
+del _environ, _DEFAULT_OPENAI_BASE_URL, _OPENAI_BASE_URL, _OPENAI_API_KEY_ENV
+
+_ROBOCASA_TASK_NAMES = [
+    'PnPBottleToCabinetClose',
+    'PnPCanToDrawerClose',
+    'PnPCupToDrawerClose',
+    'PnPMilkToMicrowaveClose',
+    'PnPPotatoToMicrowaveClose',
+    'PnPWineToCabinetClose',
+    'PosttrainPnPNovelFromCuttingboardToBasketSplitA',
+    'PosttrainPnPNovelFromCuttingboardToCardboardboxSplitA',
+    'PosttrainPnPNovelFromCuttingboardToPanSplitA',
+    'PosttrainPnPNovelFromCuttingboardToPotSplitA',
+    'PosttrainPnPNovelFromCuttingboardToTieredbasketSplitA',
+    'PosttrainPnPNovelFromPlacematToBasketSplitA',
+    'PosttrainPnPNovelFromPlacematToBowlSplitA',
+    'PosttrainPnPNovelFromPlacematToPlateSplitA',
+    'PosttrainPnPNovelFromPlacematToTieredshelfSplitA',
+    'PosttrainPnPNovelFromPlateToBowlSplitA',
+    'PosttrainPnPNovelFromPlateToCardboardboxSplitA',
+    'PosttrainPnPNovelFromPlateToPanSplitA',
+    'PosttrainPnPNovelFromPlateToPlateSplitA',
+    'PosttrainPnPNovelFromTrayToCardboardboxSplitA',
+    'PosttrainPnPNovelFromTrayToPlateSplitA',
+    'PosttrainPnPNovelFromTrayToPotSplitA',
+    'PosttrainPnPNovelFromTrayToTieredbasketSplitA',
+    'PosttrainPnPNovelFromTrayToTieredshelfSplitA',
+]
+
+eval = dict(
+    type='RobocasaEvalRunner',
+    benchmark='robocasa',
+    task_suite_name='robocasa',
+    model_family='gpt6-astra',
+    task_list=[
+        f'gr1_unified/{task_name}_GR1ArmsAndWaistFourierHands_Env'
+        for task_name in _ROBOCASA_TASK_NAMES
+    ],
+    total_tasks=len(_ROBOCASA_TASK_NAMES),
+    task_ids=[0],
+    eval_chunk_size=8,
+    max_episode_steps=720,
+    num_trials_per_task=1,
+    seed=7,
+    unnorm_key='robocasa_gr1_api_native',
+    action_order='n15',
+    action_keys={
+        'action.left_arm': (0, 7),
+        'action.right_arm': (7, 14),
+        'action.left_hand': (14, 20),
+        'action.right_hand': (20, 26),
+        'action.waist': (26, 29),
+    },
+    requires_dataset_stats=False,
+    dataset=dict(
+        type='OpenAIRobocasaEvalDataset',
+        img_keys=['video.ego_view_bg_crop_pad_res256_freq20'],
+        resize_size=512,
+    ),
+    denormalize_action=dict(
+        type='IdentityRobocasaAction', action_dim=29, clip=False),
+    denormalize_action_chunk=True,
+    model_build_device='cpu',
+    enable_mixed_precision_training=False,
+    deterministic_env=True,
+    deterministic_action_sampling=True,
+    save_video=True,
+    rollout_video_key='video.ego_view_bg_crop_pad_res256_freq20',
+    output_dir='work_dirs/gpt6_astra_robocasa',
+)
+
+del _ROBOCASA_TASK_NAMES

--- a/docs/openai_libero_control.md
+++ b/docs/openai_libero_control.md
@@ -1,0 +1,114 @@
+# GPT LIBERO control contract
+
+`configs/openai/gpt6_astra_libero_inference.py` and its named LIBERO suite
+configs use `OpenAIResponsesVLA`. All tasks remain selected by default.
+
+## Position, rotation, and gripper
+
+Example `move_to` arguments:
+
+```json
+{
+  "targets": {
+    "z": 0.85,
+    "rotation_delta": [0, 0, 0.2],
+    "gripper": 1
+  },
+  "note": "Rotate about world z to align the fingertips before descending."
+}
+```
+
+- `x`, `y`, `z`: absolute world position in meters, clipped to configured
+  workspace bounds. Omitted coordinates retain their current value.
+- `rotation_delta`: optional **relative world-frame axis-angle vector**, in
+  radians. Its direction is the rotation axis, and its length is the total
+  requested angle **for the whole call**, using the right-hand rule. It is
+  neither Euler angles nor a rotation repeated in full at each simulator step.
+  `[0, 0, 0.2]` requests about 11.5 degrees about world z. Omit it to preserve
+  orientation. The standard LIBERO Panda base axes are world-aligned.
+- `gripper`: `0` means closed, `1` means open (native LIBERO actions `+1` and
+  `-1`, respectively). Omission preserves the previous gripper command.
+
+The adapter emits normalized native `[dx, dy, dz, drx, dry, drz, gripper]`
+chunks; `IdentityLiberoAction` must not apply dataset-stat denormalization.
+Translation and rotation share the chunk duration, but have separate speed
+limits. Rotation clipping preserves the requested axis by limiting the
+vector's norm, rather than clipping its coordinates independently.
+
+The default `rotation_action_scale=0.1` estimates achieved radians per unit
+action per simulator step. It is **not** OSC's raw 0.5-radian goal offset.
+With `max_rotation_speed_fraction=0.25` and `action_horizon=10`, one call
+requests at most approximately 0.25 radians. Actual motion depends on pose,
+controller dynamics, and contact. This is an open-loop chunk between GPT
+observations, not an exact pose servo: inspect the next observation and
+correct rather than assuming the requested pose was reached.
+
+The old adapter exposed no rotation parameter, instructed GPT to keep a
+fixed orientation, and filled all three rotation channels with zero. Old
+rollouts and metrics therefore do not validate the rotation-enabled policy.
+
+The fix is confined to the API policy and its config. The existing shared
+LIBERO runner already forwards all seven action channels, including rotation;
+it does not need modification. Neither shared evaluation runner is changed.
+
+## Offline simulator diagnostic (no API key or paid requests)
+
+From the repository root in the FluxVLA environment:
+
+```bash
+MUJOCO_GL=egl python tools/check_openai_libero_control.py
+```
+
+This feeds scripted Responses tool outputs through the actual dataset,
+policy parser, chunk adapter, action transform, and real LIBERO physics. It
+checks positive/negative rotation about all three axes, XYZ translation,
+gripper signs, and a zero-rotation baseline on task 0 / trial 0. Each case
+resets the same initial state. The fresh `work_dirs/diagnostics/libero-control-*`
+directory contains `report.json` and `rotation_smoke.mp4` (external + wrist
+views). This is a controller smoke test, **not a GPT task-success evaluation**.
+
+Regression tests also cover malformed/non-finite commands, rotation omitted
+or combined with translation, per-call angular limits, and delivery of the
+rotation channels through the unchanged LIBERO run loop:
+
+```bash
+python -m pytest -q \
+  test/test_models/test_openai_libero_rotation.py \
+  test/test_models/test_openai_responses_vla.py \
+  test/test_runners/test_libero_openai_rotation_compatibility.py \
+  test/test_models/test_openai_robocasa_wrist.py \
+  test/test_configs/test_gpt6_astra_libero_config.py
+```
+
+Invalid LIBERO tool fields are rejected rather than silently ignored. The
+prompt's planning milestones follow `max_llm_calls`.
+
+## RoboCasa is a different action interface
+
+`OpenAIResponsesRobocasaVLA` uses `control_gr1`, not `move_to`. Each arm already
+exposes seven joint deltas, ordered as shoulder pitch/roll/yaw, elbow pitch,
+then wrist yaw/roll/pitch. The last three entries of `left_arm_delta` and
+`right_arm_delta` therefore control the wrists; they are not zero-filled.
+The policy converts each delta to an absolute joint target and holds that
+target over its action chunk. The 29D native action layout is left arm,
+right arm, left hand, right hand, waist. The RoboCasa identity transform
+retains those wrist values without LIBERO-style clipping or normalization.
+
+The regression test exercises both arms, all three wrist joints and both
+signs through the configured policy, transform, and runner action layout.
+No LIBERO `rotation_delta` parameter should be added to the RoboCasa config.
+
+## Separate runner issues (not changed here)
+
+Both runners check the episode step budget outside the inner action loop,
+so a final chunk can exceed the requested horizon. This is independent of
+rotation support and is deliberately left for a separate runner change.
+The default GPT RoboCasa policy always emits eight steps and its 720-step
+budget is divisible by eight; non-divisible overrides can expose the issue.
+The LIBERO successful-step counter also remains unchanged. The earlier
+runner budget/validation patch was removed to avoid mixing a shared behavior
+change with this API-specific rotation fix.
+
+To measure GPT task success again, use the normal evaluation command in a
+fresh run after setting `OPENAI_BASE_URL` and `OPENAI_API_KEY` in the shell;
+do not combine old fixed-orientation episodes with new results.

--- a/fluxvla/datasets/openai_eval_dataset.py
+++ b/fluxvla/datasets/openai_eval_dataset.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Raw LIBERO observation adapter for API-hosted policies."""
+"""Raw simulator observation adapters for API-hosted policies."""
 
 from typing import Any, Dict, List
 
@@ -70,6 +70,78 @@ class OpenAILiberoEvalDataset:
             'gripper_position':
             np.asarray(inputs['robot0_gripper_qpos']).copy(),
             'joint_position': np.asarray(inputs['robot0_joint_pos']).copy(),
+            'reset_history': bool(inputs.get('is_new_episode', False)),
+        }
+        return batch, images[0]
+
+
+@DATASETS.register_module()
+class OpenAIRobocasaEvalDataset:
+    """Prepare native RoboCasa observations for an API-hosted policy.
+
+    The adapter deliberately keeps images and robot state on CPU. The remote
+    policy owns image encoding and returns actions in the native 29D GR1
+    action order used by :class:`RobocasaEvalRunner`.
+    """
+
+    _STATE_KEYS = (
+        'state.left_arm',
+        'state.left_hand',
+        'state.right_arm',
+        'state.right_hand',
+        'state.waist',
+    )
+
+    def __init__(self,
+                 norm_stats: Any = None,
+                 unnorm_key: str = None,
+                 img_keys: List[str] = None,
+                 resize_size: int = 512) -> None:
+        del norm_stats, unnorm_key
+        self.img_keys = img_keys or [
+            'video.ego_view_bg_crop_pad_res256_freq20'
+        ]
+        self.resize_size = resize_size
+        self.last_raw_state = None
+        self.last_debug = {}
+
+    def _prepare_image(self, image: np.ndarray) -> np.ndarray:
+        image = np.asarray(image).copy()
+        if self.resize_size is not None:
+            if isinstance(self.resize_size, int):
+                size = (self.resize_size, self.resize_size)
+            else:
+                height, width = self.resize_size
+                size = (width, height)
+            image = np.asarray(
+                Image.fromarray(image).resize(size, Image.Resampling.LANCZOS))
+        return image
+
+    def __call__(self, inputs: Dict[str, Any]):
+        images = []
+        for image_key in self.img_keys:
+            if image_key not in inputs:
+                raise KeyError(f'Missing image key: {image_key!r}')
+            images.append(self._prepare_image(inputs[image_key]))
+
+        states = {}
+        for state_key in self._STATE_KEYS:
+            if state_key not in inputs:
+                raise KeyError(f'Missing state key: {state_key!r}')
+            states[state_key.removeprefix('state.')] = np.asarray(
+                inputs[state_key], dtype=np.float32).copy()
+
+        self.last_raw_state = np.concatenate([
+            states['left_arm'], states['left_hand'], states['right_arm'],
+            states['right_hand'], states['waist']
+        ])
+        task_description = str(inputs.get('task_description', ''))
+        self.last_debug = {'task_description': task_description}
+        batch = {
+            'images': images,
+            'image_names': list(self.img_keys),
+            'task_description': task_description,
+            **states,
             'reset_history': bool(inputs.get('is_new_episode', False)),
         }
         return batch, images[0]

--- a/fluxvla/engines/runners/libero_eval_runner.py
+++ b/fluxvla/engines/runners/libero_eval_runner.py
@@ -543,6 +543,12 @@ class LiberoEvalRunner(BaseEvalRunner):
     def run_setup(self):
         """Set up the evaluation environment and model."""
         set_seed_everywhere(self.seed)
+        # API-backed policies can keep the model itself on CPU, but the
+        # distributed metric tensors below still use CUDA/NCCL. Bind every
+        # rank to its local GPU before the CPU-model early return so parallel
+        # evaluation does not put all ranks' collectives on cuda:0.
+        if torch.cuda.is_available():
+            torch.cuda.set_device(self.device_id)
         self.vla.eval()
         self.vla.freeze_vision_backbone = True
         self.vla.freeze_llm_backbone = True
@@ -552,7 +558,6 @@ class LiberoEvalRunner(BaseEvalRunner):
             self.vla.to(device='cpu')
             return
 
-        torch.cuda.set_device(device_id := self.device_id)  # noqa: F841
         if self.enable_mixed_precision_training:
             self.vla.to(
                 device=self.device_id, dtype=self.mixed_precision_dtype)

--- a/fluxvla/engines/runners/libero_eval_runner.py
+++ b/fluxvla/engines/runners/libero_eval_runner.py
@@ -39,8 +39,30 @@ LIBERO_TASK_SHARDING_ALLOWED_ENV = 'FLUXVLA_ALLOW_LIBERO_TASK_SHARDING'
 
 
 def _get_libero_benchmark():
+    # LIBERO creates ``~/.libero`` during package import with a racy
+    # ``exists()`` + ``makedirs()`` sequence. Under torchrun, several ranks
+    # can observe the directory as missing and one then fails with
+    # FileExistsError. Pre-create it idempotently and let one process per node
+    # initialize config.yaml before the remaining local ranks import LIBERO.
+    libero_config_path = os.environ.get('LIBERO_CONFIG_PATH',
+                                        os.path.expanduser('~/.libero'))
+    os.makedirs(libero_config_path, exist_ok=True)
+
+    is_distributed = dist.is_available() and dist.is_initialized()
+    local_rank = overwatch.local_rank() if is_distributed else 0
+    benchmark = None
     try:
-        from libero.libero import benchmark
+        if not is_distributed or local_rank == 0:
+            from libero.libero import benchmark as imported_benchmark
+            benchmark = imported_benchmark
+        if is_distributed:
+            dist.barrier()
+            if local_rank != 0:
+                from libero.libero import benchmark as imported_benchmark
+                benchmark = imported_benchmark
+            # Do not let an early rank read config.yaml while another local
+            # rank is still completing its first LIBERO import.
+            dist.barrier()
     except ModuleNotFoundError as exc:
         raise ModuleNotFoundError(
             'LIBERO is required for simulation evaluation. Install it with '

--- a/fluxvla/engines/runners/robocasa_eval_runner.py
+++ b/fluxvla/engines/runners/robocasa_eval_runner.py
@@ -30,7 +30,6 @@ import tqdm
 from safetensors.torch import load_file
 
 from fluxvla.engines.utils import initialize_overwatch
-from fluxvla.engines.utils.name_map import str_to_dtype
 from fluxvla.engines.utils.torch_utils import set_seed_everywhere
 from ..utils.root import RUNNERS
 from .base_eval_runner import BaseEvalRunner
@@ -50,6 +49,13 @@ class RobocasaEvalRunner(BaseEvalRunner):
         task_list: RoboCasa Gymnasium environment names.
         dataset: Evaluation dataset config.
         denormalize_action: Action denormalization transform config.
+        requires_dataset_stats: Whether missing dataset statistics should fail
+            runner construction. Disable this for policies that directly emit
+            native RoboCasa actions.
+        model_build_device: Optional device passed to the eval model config
+            before construction. API-hosted policies can use ``cpu``.
+        model_build_dtype: Optional dtype passed to the eval model config
+            before construction.
         eval_chunk_size: Number of predicted actions executed per step.
         max_episode_steps: Maximum number of environment steps per episode.
         num_trials_per_task: Number of trials for each task.
@@ -102,6 +108,9 @@ class RobocasaEvalRunner(BaseEvalRunner):
                  rollout_video_key: Optional[str] = (
                      'video.ego_view_pad_res256_freq20'),
                  norm_stats_path: Optional[str] = None,
+                 requires_dataset_stats: bool = True,
+                 model_build_device: Optional[str] = None,
+                 model_build_dtype=None,
                  action_order: Optional[str] = None,
                  action_keys: Optional[Dict[str, List[int]]] = None,
                  grouped_norm_stats: bool = False,
@@ -113,12 +122,23 @@ class RobocasaEvalRunner(BaseEvalRunner):
                  result_gpu_id: Optional[int] = None,
                  **kwargs):
         from fluxvla.engines import (build_dataset_from_cfg,
-                                     build_transform_from_cfg)
+                                     build_transform_from_cfg,
+                                     build_vla_from_cfg)
 
-        self.device_id = overwatch.local_rank()
+        self.set_common_eval_attrs(cfg, seed, ckpt_path, model_family,
+                                   mixed_precision_dtype,
+                                   enable_mixed_precision_training)
+        if (model_build_device is not None
+                and str(model_build_device).startswith('cuda')
+                and torch.cuda.is_available()):
+            torch.cuda.set_device(self.device_id)
 
         # Build model.
-        self.vla = self.build_eval_vla(cfg)
+        model_cfg = self.prepare_eval_model_cfg(
+            cfg,
+            model_build_device=model_build_device,
+            model_build_dtype=model_build_dtype)
+        self.vla = build_vla_from_cfg(model_cfg).eval()
 
         # Load checkpoint weights.
         if ckpt_path is not None:
@@ -162,17 +182,20 @@ class RobocasaEvalRunner(BaseEvalRunner):
             # - official GR00T-N1.5-3B uses source prefixes and needs mapping
             # - FluxVLA-trained checkpoints already use model-native prefixes
             # This keeps PI0.5, LIBERO, and fine-tuned GR00T paths compatible.
-            model_cfg = (
+            checkpoint_model_cfg = (
                 cfg.model if hasattr(cfg, 'model') else cfg.inference_model)
-            if 'name_mapping' in model_cfg and model_cfg['name_mapping']:
+            if ('name_mapping' in checkpoint_model_cfg
+                    and checkpoint_model_cfg['name_mapping']):
                 # model_cfg.name_mapping keys are model-native prefixes, while
                 # values are external checkpoint source prefixes. Fine-tuned
                 # checkpoints are already native and must not be remapped.
                 def _has_prefix(key: str, prefix: str) -> bool:
                     return key == prefix or key.startswith(f'{prefix}.')
 
-                model_prefixes = list(model_cfg['name_mapping'].keys())
-                ckpt_prefixes = list(model_cfg['name_mapping'].values())
+                model_prefixes = list(
+                    checkpoint_model_cfg['name_mapping'].keys())
+                ckpt_prefixes = list(
+                    checkpoint_model_cfg['name_mapping'].values())
                 has_native_keys = any(
                     any(_has_prefix(k, p) for k in state_dict.keys())
                     for p in model_prefixes)
@@ -186,7 +209,7 @@ class RobocasaEvalRunner(BaseEvalRunner):
                         'applying name_mapping...')
                     mapped_state_dict = {}
                     for model_key, ckpt_key in \
-                            model_cfg['name_mapping'].items():
+                            checkpoint_model_cfg['name_mapping'].items():
                         for k, v in state_dict.items():
                             if _has_prefix(k, ckpt_key):
                                 new_key = model_key + k[len(ckpt_key):]
@@ -208,13 +231,18 @@ class RobocasaEvalRunner(BaseEvalRunner):
 
             self.vla.load_state_dict(state_dict, strict=True)
 
-        self.cfg = cfg
-        self.seed = seed
-        self.ckpt_path = ckpt_path
-        self.output_dir = output_dir
+        self.output_dir = (
+            str(Path(output_dir).expanduser().resolve())
+            if output_dir is not None else None)
         self.grouped_norm_stats = grouped_norm_stats
         self.norm_stats_group_names = norm_stats_group_names or []
-        work_dir = Path(self.ckpt_path).resolve().parent.parent
+        self.requires_dataset_stats = bool(requires_dataset_stats)
+        self.model_build_device = model_build_device
+        self.model_build_dtype = self._resolve_model_build_dtype(
+            model_build_dtype)
+        work_dir = (
+            Path(self.ckpt_path).resolve().parent.parent
+            if self.ckpt_path is not None else None)
 
         # Statistics can come from an explicit path, a default file, or groups.
         if norm_stats_path is not None and self.grouped_norm_stats:
@@ -222,6 +250,9 @@ class RobocasaEvalRunner(BaseEvalRunner):
                              'grouped_norm_stats')
 
         if self.grouped_norm_stats:
+            assert work_dir is not None, (
+                'grouped_norm_stats requires a checkpoint-relative work '
+                'directory.')
             assert len(self.norm_stats_group_names) == len(task_list), (
                 'norm_stats_group_names must have the same length as '
                 'task_list')
@@ -250,10 +281,16 @@ class RobocasaEvalRunner(BaseEvalRunner):
         else:
             data_stat_path = (
                 str(Path(norm_stats_path).expanduser().resolve())
-                if norm_stats_path is not None else os.path.join(
-                    work_dir, 'dataset_statistics.json'))
-            assert os.path.exists(data_stat_path), \
-                f'dataset_statistics.json not found at {data_stat_path}'
+                if norm_stats_path is not None else
+                os.path.join(work_dir, 'dataset_statistics.json')
+                if work_dir is not None else None)
+            if self.requires_dataset_stats:
+                assert data_stat_path is not None, (
+                    'norm_stats_path or ckpt_path is required for this '
+                    'RoboCasa evaluation config.')
+            if data_stat_path is not None:
+                assert os.path.exists(data_stat_path), \
+                    f'dataset_statistics.json not found at {data_stat_path}'
             denormalize_action['norm_stats'] = data_stat_path
             dataset['norm_stats'] = data_stat_path
             dataset['unnorm_key'] = unnorm_key
@@ -284,10 +321,7 @@ class RobocasaEvalRunner(BaseEvalRunner):
         self.num_trials_per_task = num_trials_per_task
         self.task_ids = task_ids
         self.eval_shard_strategy = eval_shard_strategy
-        self.mixed_precision_dtype = str_to_dtype(mixed_precision_dtype)
-        self.enable_mixed_precision_training = enable_mixed_precision_training
         self.unnorm_key = unnorm_key
-        self.distributed_state = overwatch.distributed_state
 
         if 'save_rollout_videos' in kwargs:
             save_video = self._coerce_bool(kwargs['save_rollout_videos'])
@@ -296,7 +330,9 @@ class RobocasaEvalRunner(BaseEvalRunner):
         self.deterministic_env = deterministic_env
         self.deterministic_action_sampling = deterministic_action_sampling
         self.run_id_suffix = run_id_suffix
-        self.result_output_dir = result_output_dir
+        self.result_output_dir = (
+            str(Path(result_output_dir).expanduser().resolve())
+            if result_output_dir is not None else None)
         self.result_gpu_id = (
             self.device_id if result_gpu_id is None else int(result_gpu_id))
 
@@ -304,7 +340,7 @@ class RobocasaEvalRunner(BaseEvalRunner):
         if self.grouped_norm_stats:
             first_g = self.norm_stats_group_names[0]
             self.vla.norm_stats = self._stats_full_by_group[first_g]
-        elif os.path.isfile(data_stat_path):
+        elif data_stat_path is not None and os.path.isfile(data_stat_path):
             with open(data_stat_path, 'r') as f:
                 self.vla.norm_stats = json.load(f)
 
@@ -421,15 +457,26 @@ class RobocasaEvalRunner(BaseEvalRunner):
         torch.cuda.manual_seed_all(seed)
 
     def run_setup(self):
-        """Initialize CUDA placement and model state."""
+        """Initialize model placement and state."""
         set_seed_everywhere(self.seed)
-        torch.cuda.set_device(self.device_id)
+        # Keep CUDA collectives rank-local even when the API-backed model is
+        # intentionally built and executed on CPU.
+        if torch.cuda.is_available():
+            torch.cuda.set_device(self.device_id)
         self.vla.eval()
         self.vla.freeze_vision_backbone = True
         self.vla.freeze_llm_backbone = True
         self.vla.freeze_projector = True
         self.vla.freeze_vlm_backbone = True
-        self.vla.cuda(self.device_id)
+        if self.model_build_device == 'cpu':
+            self.vla.to(device='cpu')
+            return
+
+        if self.enable_mixed_precision_training:
+            self.vla.to(
+                device=self.device_id, dtype=self.mixed_precision_dtype)
+        else:
+            self.vla.cuda(self.device_id)
 
     @staticmethod
     def _format_duration(seconds: float) -> str:
@@ -545,14 +592,19 @@ class RobocasaEvalRunner(BaseEvalRunner):
         return run_id
 
     @staticmethod
-    def _build_ckpt_tag(ckpt_path: str) -> str:
+    def _build_ckpt_tag(ckpt_path: str,
+                        inference_tag: Optional[str] = None) -> str:
         """Stable per-checkpoint folder name for grouping eval runs."""
+        if ckpt_path is None:
+            tag = str(inference_tag or 'inference-only')
+            return tag.replace('/', '-').replace('\\', '-')
         return Path(ckpt_path).resolve().stem
 
     @staticmethod
     def _build_run_dir(ckpt_path: str,
                        run_id: str,
-                       output_dir: Optional[str] = None) -> str:
+                       output_dir: Optional[str] = None,
+                       inference_tag: Optional[str] = None) -> str:
         """Per-checkpoint, per-run output directory.
 
         This mirrors ``LiberoEvalRunner`` so RoboCasa and LIBERO eval outputs
@@ -560,11 +612,14 @@ class RobocasaEvalRunner(BaseEvalRunner):
         """
         if output_dir is not None:
             root = Path(output_dir).expanduser().resolve()
+        elif ckpt_path is None:
+            root = Path('work_dirs').resolve()
         else:
             root = Path(ckpt_path).resolve().parent.parent
-        return os.path.join(root, 'eval_runs',
-                            RobocasaEvalRunner._build_ckpt_tag(ckpt_path),
-                            run_id)
+        return os.path.join(
+            root, 'eval_runs',
+            RobocasaEvalRunner._build_ckpt_tag(
+                ckpt_path, inference_tag=inference_tag), run_id)
 
     def _write_robocasa_summary_artifacts(self, run_dir: Path, run_id: str,
                                           task_successes, task_episodes,
@@ -791,7 +846,10 @@ class RobocasaEvalRunner(BaseEvalRunner):
         if output_root is None:
             output_root = self.result_output_dir
         self.run_dir = self._build_run_dir(
-            self.ckpt_path, run_id, output_dir=output_root)
+            self.ckpt_path,
+            run_id,
+            output_dir=output_root,
+            inference_tag=self.model_family)
         os.makedirs(self.run_dir, exist_ok=True)
         log_filepath = os.path.join(self.run_dir, f'rank{rank}.txt')
         log_file = open(log_filepath, 'w', encoding='utf-8', buffering=1)
@@ -804,14 +862,14 @@ class RobocasaEvalRunner(BaseEvalRunner):
         log_file.write(f'Task ids: {task_ids}\n')
         log_file.write(f'Eval shard strategy: {self.eval_shard_strategy}\n')
 
-        total_episodes = torch.zeros(1, device=torch.cuda.current_device())
-        total_successes = torch.zeros(1, device=torch.cuda.current_device())
-        task_successes = torch.zeros(
-            num_tasks, device=torch.cuda.current_device())
-        task_episodes = torch.zeros(
-            num_tasks, device=torch.cuda.current_device())
-        task_durations = torch.zeros(
-            num_tasks, device=torch.cuda.current_device())
+        reduction_device = (
+            torch.device('cuda', torch.cuda.current_device())
+            if torch.cuda.is_available() else torch.device('cpu'))
+        total_episodes = torch.zeros(1, device=reduction_device)
+        total_successes = torch.zeros(1, device=reduction_device)
+        task_successes = torch.zeros(num_tasks, device=reduction_device)
+        task_episodes = torch.zeros(num_tasks, device=reduction_device)
+        task_durations = torch.zeros(num_tasks, device=reduction_device)
 
         pbar = None
         if rank == 0:
@@ -822,8 +880,7 @@ class RobocasaEvalRunner(BaseEvalRunner):
 
         for idx in range(num_local_episodes):
             if idx >= len(local_episodes):
-                step_tensor = torch.zeros(
-                    1, device=torch.cuda.current_device())
+                step_tensor = torch.zeros(1, device=reduction_device)
             else:
                 local_id = local_episodes[idx]
                 task_id = local_id // self.num_trials_per_task
@@ -880,6 +937,7 @@ class RobocasaEvalRunner(BaseEvalRunner):
                 while t < self.max_episode_steps:
                     # Build input dict for the dataset transform pipeline.
                     obs['task_description'] = task_desc
+                    obs['is_new_episode'] = (t == 0)
                     batch, _ = self.dataset(obs)
                     debug_info = getattr(self.dataset, 'last_debug', {})
                     if t == 0:
@@ -908,7 +966,8 @@ class RobocasaEvalRunner(BaseEvalRunner):
                     with torch.autocast(
                             'cuda',
                             dtype=self.mixed_precision_dtype,
-                            enabled=self.enable_mixed_precision_training):
+                            enabled=(self.enable_mixed_precision_training
+                                     and self.model_build_device != 'cpu')):
                         with torch.no_grad():
                             actions = self.vla.predict_action(**batch)
 
@@ -1051,7 +1110,7 @@ class RobocasaEvalRunner(BaseEvalRunner):
                         overwatch.warning(f'  Video save failed: {e}')
 
                 env.close()
-                step_tensor = torch.ones(1, device=torch.cuda.current_device())
+                step_tensor = torch.ones(1, device=reduction_device)
 
             # Distributed synchronization.
             dist.barrier()

--- a/fluxvla/engines/runners/robocasa_eval_runner.py
+++ b/fluxvla/engines/runners/robocasa_eval_runner.py
@@ -472,11 +472,20 @@ class RobocasaEvalRunner(BaseEvalRunner):
             self.vla.to(device='cpu')
             return
 
-        if self.enable_mixed_precision_training:
-            self.vla.to(
-                device=self.device_id, dtype=self.mixed_precision_dtype)
-        else:
+        # Preserve the historical checkpoint-evaluation behavior unless the
+        # config explicitly requests a construction-time device or dtype.
+        # ``enable_mixed_precision_training`` controls autocast below; it must
+        # not implicitly cast every model parameter to BF16 because some
+        # policies intentionally keep selected flow modules in FP32.
+        if self.model_build_device is None and self.model_build_dtype is None:
             self.vla.cuda(self.device_id)
+            return
+
+        target_device = self.model_build_device or self.device_id
+        to_kwargs = dict(device=target_device)
+        if self.model_build_dtype is not None:
+            to_kwargs['dtype'] = self.model_build_dtype
+        self.vla.to(**to_kwargs)
 
     @staticmethod
     def _format_duration(seconds: float) -> str:

--- a/fluxvla/engines/utils/eval_episode_store.py
+++ b/fluxvla/engines/utils/eval_episode_store.py
@@ -1,0 +1,145 @@
+# Copyright 2026 Limx Dynamics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Durable LIBERO episode outcomes, including recovery of older rank logs."""
+
+import json
+import math
+import os
+import re
+import tempfile
+from pathlib import Path
+
+
+class EvalEpisodeStore:
+    """Store completed trials only; an API error is not a failed trial.
+
+    Each trial is written atomically, independently of the final distributed
+    reduction. Legacy logs can recover success/failure but not rollout timing.
+    """
+
+    def __init__(self, run_dir, metadata):
+        self.run_dir = Path(run_dir)
+        # Normalize ConfigDict / tuple values to the persisted representation.
+        self.metadata = json.loads(json.dumps(metadata, default=str))
+        self.episode_dir = self.run_dir / 'episode_results'
+
+    @staticmethod
+    def _atomic_json(path, value):
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, temporary = tempfile.mkstemp(
+            prefix=f'.{path.name}.', dir=path.parent)
+        try:
+            with os.fdopen(fd, 'w', encoding='utf-8') as stream:
+                json.dump(value, stream, indent=2, allow_nan=False)
+                stream.write('\n')
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.replace(temporary, path)
+        finally:
+            if os.path.exists(temporary):
+                os.unlink(temporary)
+
+    def _validate_record(self, record):
+        task_id, trial_id = record['task_id'], record['trial_id']
+        if (type(task_id) is not int or type(trial_id) is not int
+                or task_id not in self.metadata['task_ids']
+                or not 0 <= trial_id < self.metadata['num_trials_per_task']):
+            raise ValueError(f'Invalid resumed episode: {(task_id, trial_id)}')
+        if (record.get('task_suite') != self.metadata['task_suite_name']
+                or record.get('status') != 'completed'
+                or type(record.get('success')) is not bool):
+            raise ValueError(f'Invalid episode outcome: {(task_id, trial_id)}')
+        for key in ('duration_seconds', 'start_time'):
+            value = record.get(key)
+            if value is not None and (not math.isfinite(float(value))
+                                      or float(value) < 0):
+                raise ValueError(f'Invalid episode {key}: {value}')
+        return task_id, trial_id
+
+    def save(self, record):
+        task_id, trial_id = self._validate_record(record)
+        path = self.episode_dir / f'task{task_id}_trial{trial_id}.json'
+        self._atomic_json(path, record)
+
+    def _legacy_records(self):
+        """Only an explicit final Success line proves that a trial finished."""
+        records = {}
+        for path in sorted(self.run_dir.glob('rank*.txt')):
+            current = None
+            for line in path.read_text(encoding='utf-8').splitlines():
+                match = re.fullmatch(r'Evaluating Task (\d+), Trial (\d+)',
+                                     line)
+                if match:
+                    current = tuple(map(int, match.groups()))
+                elif current is not None and line in ('Success: True',
+                                                      'Success: False'):
+                    record = dict(
+                        task_suite=self.metadata['task_suite_name'],
+                        task_id=current[0],
+                        trial_id=current[1],
+                        status='completed',
+                        success=line == 'Success: True',
+                        duration_seconds=None,
+                        start_time=None,
+                        recovered_from=path.name)
+                    self._validate_record(record)
+                    if (current in records and
+                            records[current]['success'] != record['success']):
+                        raise ValueError(
+                            f'Conflicting legacy outcome: {current}')
+                    records[current] = record
+                    current = None
+        return records
+
+    def prepare(self, resume=False):
+        """Called by rank zero before other ranks begin writing results."""
+        metadata_path = self.run_dir / 'eval_metadata.json'
+        if metadata_path.exists():
+            stored = json.loads(metadata_path.read_text(encoding='utf-8'))
+            if stored['evaluation'] != self.metadata:
+                changed = sorted(
+                    k for k in set(stored['evaluation']) | set(self.metadata)
+                    if stored['evaluation'].get(k) != self.metadata.get(k))
+                raise ValueError('Resume evaluation settings differ: ' +
+                                 ', '.join(changed))
+        elif resume:
+            expected_prefix = (f'EVAL-{self.metadata["task_suite_name"]}-'
+                               f'{self.metadata["model_family"]}-')
+            if (not self.run_dir.name.startswith(expected_prefix)
+                    or not list(self.run_dir.glob('rank*.txt'))):
+                raise ValueError('Resume directory has no matching LIBERO run')
+
+        records = self._legacy_records() if resume else {}
+        for path in sorted(self.episode_dir.glob('*.json')):
+            record = json.loads(path.read_text(encoding='utf-8'))
+            pair = self._validate_record(record)
+            if (pair in records
+                    and records[pair]['success'] != record['success']):
+                raise ValueError(f'Conflicting stored outcome: {pair}')
+            records[pair] = record
+
+        if not resume and records:
+            raise ValueError('Run already contains episodes; use resume_from')
+        # Preserve every recovered legacy outcome before launching new work.
+        for record in records.values():
+            self.save(record)
+        if not metadata_path.exists():
+            self._atomic_json(
+                metadata_path,
+                dict(
+                    schema_version=1,
+                    evaluation=self.metadata,
+                    legacy_metadata_unverified=bool(resume)))
+        return records

--- a/fluxvla/models/vlas/__init__.py
+++ b/fluxvla/models/vlas/__init__.py
@@ -34,6 +34,7 @@ import_heterogeneous_runtime_symbols(
         'dreamzero_vla': ['DreamZeroVLA'],
         'fastwam_vla': ['FastWAMVLA'],
         'cosmos3_flowmatching': ['Cosmos3FlowMatching'],
-        'openai_responses_vla': ['OpenAIResponsesVLA'],
+        'openai_responses_vla':
+        ['OpenAIResponsesVLA', 'OpenAIResponsesRobocasaVLA'],
     },
 )

--- a/fluxvla/models/vlas/openai_responses_vla.py
+++ b/fluxvla/models/vlas/openai_responses_vla.py
@@ -23,6 +23,7 @@ import os
 import time
 import urllib.error
 import urllib.request
+from numbers import Real
 from typing import Any, Dict, List, Sequence
 
 import numpy as np
@@ -41,9 +42,17 @@ call to make progress on the instruction. The simulator, not you, decides
 when the task succeeds.
 
 The move_to tool accepts an absolute end-effector position in MuJoCo world
-coordinates. Unspecified dimensions hold their current value. The default
-downward-facing gripper orientation is held fixed. Use small, deliberate
-motions and re-check the next observation after every command. Approach an
+coordinates and an optional rotation_delta [rx, ry, rz]. This is a relative
+axis-angle rotation vector in radians about WORLD axes, NOT Euler angles or
+an absolute orientation. Its direction is the rotation axis and its length
+is the angle, using the right-hand rule. For example [0, 0, 0.2] turns the
+gripper about world z; [0, 0, -0.2] turns it the other way. It is the total
+requested rotation for this call, not a delta to repeat at every step.
+Omitted position dimensions and omitted rotation hold their previous value.
+Rotate to align the fingertips with an object's grasp axis or a handle before
+descending; tilt only when needed. Motions are speed-limited and may only
+partially reach a requested target. Re-check the reported pose and images
+after every command rather than assuming the target was reached. Approach an
 object from above, descend only after it is centered between the fingertips,
 close the gripper, lift clear of obstacles, move above the destination,
 descend, open the gripper, and retreat when appropriate.
@@ -113,6 +122,8 @@ class OpenAIResponsesVLA(nn.Module):
                  action_horizon: int = 10,
                  max_speed_fraction: float = 0.25,
                  position_action_scale: float = 0.01,
+                 rotation_action_scale: float = 0.1,
+                 max_rotation_speed_fraction: float = 0.25,
                  gripper_settle_steps: int = 8,
                  workspace_bounds: Sequence[Sequence[float]] = ((-0.45, 0.45),
                                                                 (-0.45, 0.45),
@@ -127,10 +138,22 @@ class OpenAIResponsesVLA(nn.Module):
             raise ValueError('action_horizon must be at least 1')
         if not 0 < max_speed_fraction <= 1:
             raise ValueError('max_speed_fraction must be in (0, 1]')
-        if position_action_scale <= 0:
-            raise ValueError('position_action_scale must be positive')
-        if len(workspace_bounds) != 3:
-            raise ValueError('workspace_bounds must contain x/y/z bounds')
+        if (not math.isfinite(position_action_scale)
+                or position_action_scale <= 0):
+            raise ValueError(
+                'position_action_scale must be finite and positive')
+        if (not math.isfinite(rotation_action_scale)
+                or rotation_action_scale <= 0):
+            raise ValueError(
+                'rotation_action_scale must be finite and positive')
+        if not 0 < max_rotation_speed_fraction <= 1:
+            raise ValueError('max_rotation_speed_fraction must be in (0, 1]')
+        bounds_array = np.asarray(workspace_bounds, dtype=np.float64)
+        if (bounds_array.shape != (3, 2)
+                or not np.all(np.isfinite(bounds_array))
+                or np.any(bounds_array[:, 0] >= bounds_array[:, 1])):
+            raise ValueError(
+                'workspace_bounds must contain finite, ordered x/y/z bounds')
 
         self.model = model
         self.base_url = base_url.rstrip('/')
@@ -148,6 +171,8 @@ class OpenAIResponsesVLA(nn.Module):
         self.action_horizon = int(action_horizon)
         self.max_speed_fraction = float(max_speed_fraction)
         self.position_action_scale = float(position_action_scale)
+        self.rotation_action_scale = float(rotation_action_scale)
+        self.max_rotation_speed_fraction = float(max_rotation_speed_fraction)
         self.gripper_settle_steps = int(gripper_settle_steps)
         self.workspace_bounds = tuple((float(bounds[0]), float(bounds[1]))
                                       for bounds in workspace_bounds)
@@ -176,10 +201,19 @@ class OpenAIResponsesVLA(nn.Module):
     @property
     def tools(self) -> List[Dict[str, Any]]:
         x_bounds, y_bounds, z_bounds = self.workspace_bounds
+        max_rotation = (
+            self.action_horizon * self.rotation_action_scale *
+            self.max_rotation_speed_fraction)
         description = (
             'Move the robot end effector to an absolute Cartesian target. '
-            'Omitted x/y/z dimensions keep their current value. The fixed '
-            'downward gripper orientation is preserved. Bounds: '
+            'Omitted x/y/z dimensions keep their current value. Optional '
+            'rotation_delta is a relative WORLD-frame axis-angle vector '
+            'in radians for the whole call, not Euler angles. Omit it to '
+            'hold orientation. Rotation magnitude is limited to approximately '
+            f'{max_rotation:.3f} '
+            'radians per call; inspect the next observation for the '
+            'achieved pose. '
+            'Position bounds (meters): '
             f'x=[{x_bounds[0]}, {x_bounds[1]}], '
             f'y=[{y_bounds[0]}, {y_bounds[1]}], '
             f'z=[{z_bounds[0]}, {z_bounds[1]}]. Gripper target 0 is fully '
@@ -202,6 +236,23 @@ class OpenAIResponsesVLA(nn.Module):
                             },
                             'z': {
                                 'type': 'number'
+                            },
+                            'rotation_delta': {
+                                'type':
+                                'array',
+                                'items': {
+                                    'type': 'number'
+                                },
+                                'minItems':
+                                3,
+                                'maxItems':
+                                3,
+                                'description':
+                                ('Relative world-axis rotation vector '
+                                 '[rx, ry, rz], radians, right-hand rule. '
+                                 'For yaw alignment use [0, 0, angle]. '
+                                 'Not Euler angles; omit to hold '
+                                 'orientation.'),
                             },
                             'gripper': {
                                 'type': 'number',
@@ -316,16 +367,22 @@ class OpenAIResponsesVLA(nn.Module):
                              eef_quaternion: Any,
                              gripper_position: Any,
                              joint_position: Any = None) -> Dict[str, Any]:
-        position = self._unbatch_array(eef_position).reshape(-1)
-        quaternion = self._unbatch_array(eef_quaternion).reshape(-1)
+        position = self._state_vector(eef_position, 3, 'eef_position')
+        quaternion = self._state_vector(eef_quaternion, 4, 'eef_quaternion')
+        if np.linalg.norm(quaternion) < 1e-8:
+            raise RuntimeError('eef_quaternion must be nonzero')
         gripper = self._unbatch_array(gripper_position).reshape(-1)
+        identify, grasp, release = [
+            max(1, math.ceil(self.max_llm_calls * fraction))
+            for fraction in (0.2, 0.5, 0.9)
+        ]
         lines = [
             'Current observation.',
             f'Instruction: {task_description}',
             (f'Action call: {self._llm_calls + 1}/{self.max_llm_calls}. '
              'Use the call budget efficiently: identify the target by call '
-             '10, aim to grasp by call 25, and release it at the destination '
-             'by call 45.'),
+             f'{identify}, aim to grasp by call {grasp}, and release it at '
+             f'the destination by call {release}.'),
             'robot0_eef_pos (x, y, z meters): ' +
             np.array2string(position, precision=5, separator=', '),
             'robot0_eef_quat (x, y, z, w): ' +
@@ -450,38 +507,88 @@ class OpenAIResponsesVLA(nn.Module):
             )
         return calls[0]
 
+    @classmethod
+    def _state_vector(cls, value: Any, length: int, name: str) -> np.ndarray:
+        vector = cls._unbatch_array(value).astype(np.float64)
+        if vector.shape != (length, ) or not np.all(np.isfinite(vector)):
+            raise RuntimeError(f'{name} must contain {length} finite values')
+        return vector
+
+    @staticmethod
+    def _target_number(value: Any, name: str) -> float:
+        if (isinstance(value, (bool, np.bool_)) or not isinstance(value, Real)
+                or not math.isfinite(value)):
+            raise RuntimeError(f'move_to.{name} must be a finite number')
+        return float(value)
+
     def _actions_from_targets(self, targets: Dict[str, Any],
                               eef_position: Any) -> torch.Tensor:
-        current = self._unbatch_array(eef_position).astype(
-            np.float64).reshape(-1)[:3]
+        if not isinstance(targets, dict):
+            raise RuntimeError('move_to.targets must be an object')
+        unknown = set(targets) - {'x', 'y', 'z', 'rotation_delta', 'gripper'}
+        if unknown:
+            raise RuntimeError(
+                f'Unknown move_to target fields: {sorted(unknown)}')
+        current = self._state_vector(eef_position, 3, 'eef_position')
         target = current.copy()
         for index, key in enumerate(('x', 'y', 'z')):
             if key in targets:
                 lo, hi = self.workspace_bounds[index]
-                target[index] = np.clip(float(targets[key]), lo, hi)
+                target[index] = np.clip(
+                    self._target_number(targets[key], key), lo, hi)
 
         delta = target - current
         max_step = self.position_action_scale * self.max_speed_fraction
-        move_steps = int(math.ceil(np.max(np.abs(delta)) / max_step)) \
-            if np.any(delta) else 1
+        move_steps = 1
+        if np.any(delta):
+            move_steps = math.ceil(
+                min(self.action_horizon,
+                    np.max(np.abs(delta)) / max_step))
 
-        gripper_target = targets.get('gripper')
-        if gripper_target is None:
+        rotation_delta = np.zeros(3, dtype=np.float64)
+        if 'rotation_delta' in targets:
+            value = targets['rotation_delta']
+            if not isinstance(value, (list, tuple)) or len(value) != 3:
+                raise RuntimeError(
+                    'move_to.rotation_delta must contain 3 finite numbers')
+            rotation_delta = np.array([
+                self._target_number(item, 'rotation_delta') for item in value
+            ])
+        rotation_angle = math.hypot(*rotation_delta)
+        if not math.isfinite(rotation_angle):
+            raise RuntimeError(
+                'move_to.rotation_delta magnitude must be finite')
+        max_rotation_step = (
+            self.rotation_action_scale * self.max_rotation_speed_fraction)
+        # Bound the vector's norm, not its individual coordinates, to preserve
+        # the requested world rotation axis. LIBERO's fixed Panda base is
+        # world-aligned. Native OSC rotation inputs are axis-angle deltas, not
+        # Euler angles or deltas in the gripper's local frame.
+        max_rotation = self.action_horizon * max_rotation_step
+        if rotation_angle > max_rotation:
+            rotation_delta *= max_rotation / rotation_angle
+            rotation_angle = max_rotation
+        rotation_steps = max(1, math.ceil(rotation_angle / max_rotation_step))
+
+        if 'gripper' not in targets:
             gripper_action = self._last_gripper_action
             gripper_steps = 1
-        elif float(gripper_target) >= 0.5:
-            gripper_action = -1.0
-            gripper_steps = self.gripper_settle_steps
         else:
-            gripper_action = 1.0
+            gripper_target = self._target_number(targets['gripper'], 'gripper')
+            if not 0 <= gripper_target <= 1:
+                raise RuntimeError('move_to.gripper must be in [0, 1]')
+            gripper_action = -1.0 if gripper_target >= 0.5 else 1.0
             gripper_steps = self.gripper_settle_steps
         self._last_gripper_action = gripper_action
 
-        num_steps = min(self.action_horizon, max(1, move_steps, gripper_steps))
+        num_steps = min(self.action_horizon,
+                        max(1, move_steps, rotation_steps, gripper_steps))
         xyz_action = np.clip(delta / (num_steps * self.position_action_scale),
                              -self.max_speed_fraction, self.max_speed_fraction)
+        rotation_action = rotation_delta / (
+            num_steps * self.rotation_action_scale)
         action = np.concatenate(
-            [xyz_action, np.zeros(3),
+            [xyz_action, rotation_action,
              np.array([gripper_action])])
         actions = np.repeat(action[None], num_steps, axis=0)
         return torch.from_numpy(actions.astype(np.float32)).unsqueeze(0)
@@ -538,7 +645,12 @@ class OpenAIResponsesVLA(nn.Module):
             raise RuntimeError(
                 f'Invalid move_to arguments: {call.get("arguments")!r}') \
                 from exc
-        targets = arguments.get('targets', {})
+        if not isinstance(arguments, dict):
+            raise RuntimeError('move_to arguments must be an object')
+        unknown = set(arguments) - {'targets', 'note'}
+        if unknown:
+            raise RuntimeError(f'Unknown move_to arguments: {sorted(unknown)}')
+        targets = arguments.get('targets')
         if not isinstance(targets, dict):
             raise RuntimeError('move_to.targets must be an object')
         self.last_note = str(arguments.get('note', ''))

--- a/fluxvla/models/vlas/openai_responses_vla.py
+++ b/fluxvla/models/vlas/openai_responses_vla.py
@@ -63,6 +63,29 @@ supported match. Include a short note describing what you see and why you
 chose the target. Do not guess object coordinates from simulator-only
 metadata; use the images and the reported robot state."""
 
+DEFAULT_ROBOCASA_SYSTEM_PROMPT = """You control a Fourier GR-1 humanoid in the
+RoboCasa tabletop simulator. At every turn you receive one or more ego-camera
+images and the current left-arm, right-arm, hand, and waist joint states. Use
+exactly one control_gr1 tool call to make progress on the instruction. The
+simulator, not you, decides when the task succeeds.
+
+The two arm vectors use this joint order: shoulder pitch, shoulder roll,
+shoulder yaw, elbow pitch, wrist yaw, wrist roll, wrist pitch. The waist order
+is yaw, pitch, roll. Arm and waist values supplied to the tool are incremental
+joint changes from the reported state; the controller clips them to a safe
+per-call magnitude and converts them to absolute joint targets. Omit an arm or
+waist vector to hold it. Each hand accepts open, close, or hold. Use small,
+deliberate motions, change only the joints needed for the current sub-goal,
+and inspect the next image before correcting the motion.
+
+The ego camera is mounted on the robot and faces the work surface. Plan a
+short sequence: identify the source and destination, choose the nearer arm,
+approach, close the selected hand, lift, move to the destination, open the
+hand, and retreat. Keep the unused hand open and away from the workspace.
+Include a short note describing what you see and why you chose the command.
+Use only the camera images and reported robot state; do not assume hidden
+simulator metadata."""
+
 
 @VLAS.register_module()
 class OpenAIResponsesVLA(nn.Module):
@@ -545,5 +568,369 @@ class OpenAIResponsesVLA(nn.Module):
             call_id,
             'output':
             f'executing move_to over {actions.shape[1]} steps',
+        })
+        return actions
+
+
+@VLAS.register_module()
+class OpenAIResponsesRobocasaVLA(OpenAIResponsesVLA):
+    """Checkpoint-free Responses API policy for RoboCasa GR1 evaluation.
+
+    The API emits bounded joint deltas plus discrete hand commands. They are
+    converted to native, absolute GR1 controller targets in N1.5 order:
+    left arm, right arm, left hand, right hand, then waist.
+    """
+
+    OPEN_HAND_ACTION = np.array([-1.5, -1.5, -1.5, -1.5, -3.0, 3.0],
+                                dtype=np.float32)
+    CLOSE_HAND_ACTION = np.array([1.5, 1.5, 1.5, 1.5, 3.0, 3.0],
+                                 dtype=np.float32)
+
+    def __init__(self,
+                 model: str = 'gpt-6-astra',
+                 base_url: str = 'https://api.openai.com/v1',
+                 api_key_env: str = 'OPENAI_API_KEY',
+                 reasoning_effort: str = 'medium',
+                 max_output_tokens: int = None,
+                 request_timeout: float = 120.0,
+                 max_retries: int = 2,
+                 retry_backoff: float = 2.0,
+                 image_detail: str = 'high',
+                 image_format: str = 'JPEG',
+                 jpeg_quality: int = 95,
+                 image_horizon: int = 2,
+                 max_llm_calls: int = 90,
+                 action_horizon: int = 8,
+                 max_arm_joint_delta: float = 0.12,
+                 max_waist_joint_delta: float = 0.05,
+                 left_arm_joint_bounds: Sequence[Sequence[float]] = (
+                     (-3.0, 3.0), (0.0, 3.0), (-3.0, 3.0), (-3.0, 0.0),
+                     (-3.0, 3.0), (-1.5, 1.5), (-1.5, 1.5)),
+                 right_arm_joint_bounds: Sequence[Sequence[float]] = (
+                     (-3.0, 3.0), (-3.0, 0.0), (-3.0, 3.0), (-3.0, 0.0),
+                     (-3.0, 3.0), (-1.5, 1.5), (-1.5, 1.5)),
+                 waist_joint_bounds: Sequence[Sequence[float]] = ((-1.05,
+                                                                   1.05),
+                                                                  (-0.52,
+                                                                   1.22),
+                                                                  (-0.70,
+                                                                   0.70)),
+                 system_prompt: str = DEFAULT_ROBOCASA_SYSTEM_PROMPT,
+                 task_visual_hints: Dict[str, str] = None,
+                 device: str = None,
+                 torch_dtype=None) -> None:
+        super().__init__(
+            model=model,
+            base_url=base_url,
+            api_key_env=api_key_env,
+            reasoning_effort=reasoning_effort,
+            max_output_tokens=max_output_tokens,
+            request_timeout=request_timeout,
+            max_retries=max_retries,
+            retry_backoff=retry_backoff,
+            image_detail=image_detail,
+            image_format=image_format,
+            jpeg_quality=jpeg_quality,
+            image_horizon=image_horizon,
+            max_llm_calls=max_llm_calls,
+            action_horizon=action_horizon,
+            system_prompt=system_prompt,
+            task_visual_hints=task_visual_hints,
+            device=device,
+            torch_dtype=torch_dtype)
+        if max_arm_joint_delta <= 0 or max_waist_joint_delta <= 0:
+            raise ValueError('RoboCasa joint delta limits must be positive')
+        if len(left_arm_joint_bounds) != 7:
+            raise ValueError('left_arm_joint_bounds must contain seven pairs')
+        if len(right_arm_joint_bounds) != 7:
+            raise ValueError('right_arm_joint_bounds must contain seven pairs')
+        if len(waist_joint_bounds) != 3:
+            raise ValueError('waist_joint_bounds must contain three pairs')
+        self.max_arm_joint_delta = float(max_arm_joint_delta)
+        self.max_waist_joint_delta = float(max_waist_joint_delta)
+        self.left_arm_joint_bounds = tuple((float(bounds[0]), float(bounds[1]))
+                                           for bounds in left_arm_joint_bounds)
+        self.right_arm_joint_bounds = tuple(
+            (float(bounds[0]), float(bounds[1]))
+            for bounds in right_arm_joint_bounds)
+        self.waist_joint_bounds = tuple((float(bounds[0]), float(bounds[1]))
+                                        for bounds in waist_joint_bounds)
+        self._last_left_hand_action = self.OPEN_HAND_ACTION.copy()
+        self._last_right_hand_action = self.OPEN_HAND_ACTION.copy()
+
+    @property
+    def tools(self) -> List[Dict[str, Any]]:
+        arm_description = (
+            'Seven incremental joint changes in radians, ordered as shoulder '
+            'pitch, shoulder roll, shoulder yaw, elbow pitch, wrist yaw, '
+            'wrist roll, wrist pitch. Values are clipped to '
+            f'+/-{self.max_arm_joint_delta} per call.')
+        waist_description = (
+            'Three incremental joint changes in radians, ordered as yaw, '
+            f'pitch, roll. Values are clipped to '
+            f'+/-{self.max_waist_joint_delta} per call.')
+        vector = lambda length, description: {  # noqa: E731
+            'type': 'array',
+            'items': {
+                'type': 'number'
+            },
+            'minItems': length,
+            'maxItems': length,
+            'description': description,
+        }
+        return [{
+            'type':
+            'function',
+            'name':
+            'control_gr1',
+            'description':
+            ('Apply one bounded GR1 joint-space command and then observe '
+             'again. Omitted joint groups hold their current position.'),
+            'parameters': {
+                'type': 'object',
+                'properties': {
+                    'left_arm_delta': vector(7, arm_description),
+                    'right_arm_delta': vector(7, arm_description),
+                    'waist_delta': vector(3, waist_description),
+                    'left_hand': {
+                        'type': 'string',
+                        'enum': ['hold', 'open', 'close'],
+                    },
+                    'right_hand': {
+                        'type': 'string',
+                        'enum': ['hold', 'open', 'close'],
+                    },
+                    'note': {
+                        'type':
+                        'string',
+                        'description':
+                        ('One or two sentences describing the current '
+                         'observation and why this command was chosen.'),
+                    },
+                },
+                'required': ['note'],
+                'additionalProperties': False,
+            },
+            'strict':
+            False,
+        }]
+
+    def _reset_episode(self, task_description: str) -> None:
+        super()._reset_episode(task_description)
+        self._last_left_hand_action = self.OPEN_HAND_ACTION.copy()
+        self._last_right_hand_action = self.OPEN_HAND_ACTION.copy()
+
+    @staticmethod
+    def _joint_vector(value: Any, length: int, name: str) -> np.ndarray:
+        vector = np.asarray(value, dtype=np.float64).reshape(-1)
+        if vector.shape[0] != length:
+            raise RuntimeError(
+                f'{name} must contain exactly {length} values, got '
+                f'{vector.shape[0]}.')
+        if not np.all(np.isfinite(vector)):
+            raise RuntimeError(f'{name} contains a non-finite value.')
+        return vector
+
+    @staticmethod
+    def _apply_delta(current: np.ndarray, command: Dict[str, Any], key: str,
+                     max_delta: float, bounds) -> np.ndarray:
+        if key not in command:
+            return current.copy()
+        delta = OpenAIResponsesRobocasaVLA._joint_vector(
+            command[key], current.shape[0], key)
+        target = current + np.clip(delta, -max_delta, max_delta)
+        bounds_array = np.asarray(bounds, dtype=np.float64)
+        if bounds_array.ndim == 1:
+            return np.clip(target, bounds_array[0], bounds_array[1])
+        return np.clip(target, bounds_array[:, 0], bounds_array[:, 1])
+
+    def _hand_action(self, command: str, side: str) -> np.ndarray:
+        command = str(command or 'hold').lower()
+        attr = f'_last_{side}_hand_action'
+        if command == 'open':
+            action = self.OPEN_HAND_ACTION.copy()
+        elif command == 'close':
+            action = self.CLOSE_HAND_ACTION.copy()
+        elif command == 'hold':
+            action = getattr(self, attr).copy()
+        else:
+            raise RuntimeError(
+                f'{side}_hand must be open, close, or hold; got {command!r}.')
+        setattr(self, attr, action.copy())
+        return action
+
+    def _robocasa_observation_message(self, images: Sequence[Any],
+                                      image_names: Sequence[str],
+                                      task_description: str, left_arm: Any,
+                                      left_hand: Any, right_arm: Any,
+                                      right_hand: Any,
+                                      waist: Any) -> Dict[str, Any]:
+        state_lines = [
+            'Current observation.',
+            f'Instruction: {task_description}',
+            f'Action call: {self._llm_calls + 1}/{self.max_llm_calls}.',
+        ]
+        for name, value in (
+            ('left_arm', left_arm),
+            ('left_hand', left_hand),
+            ('right_arm', right_arm),
+            ('right_hand', right_hand),
+            ('waist', waist),
+        ):
+            vector = self._unbatch_array(value).reshape(-1)
+            state_lines.append(
+                f'{name}: ' +
+                np.array2string(vector, precision=5, separator=', '))
+        content: List[Dict[str, Any]] = [{
+            'type': 'input_text',
+            'text': '\n'.join(state_lines),
+        }]
+        for name, image in zip(image_names, images):
+            content.append({
+                'type': 'input_text',
+                'text': f"camera '{name}':",
+            })
+            image_item = {
+                'type': 'input_image',
+                'image_url': self._image_data_url(image),
+            }
+            if self.image_detail:
+                image_item['detail'] = self.image_detail
+            content.append(image_item)
+        return {'role': 'user', 'content': content}
+
+    @staticmethod
+    def _robocasa_function_call(response: Dict[str, Any]) -> Dict[str, Any]:
+        calls = [
+            item for item in response.get('output', [])
+            if item.get('type') == 'function_call'
+            and item.get('name') == 'control_gr1'
+        ]
+        if len(calls) != 1:
+            output_types = [
+                item.get('type') for item in response.get('output', [])
+            ]
+            raise RuntimeError(
+                'Expected exactly one control_gr1 tool call from the OpenAI '
+                f'Responses API, got {len(calls)}; output types={output_types}'
+            )
+        return calls[0]
+
+    def _robocasa_actions(self, command: Dict[str, Any], left_arm: Any,
+                          right_arm: Any, waist: Any) -> torch.Tensor:
+        left_arm = self._unbatch_array(left_arm).astype(np.float64).reshape(-1)
+        right_arm = self._unbatch_array(right_arm).astype(
+            np.float64).reshape(-1)
+        waist = self._unbatch_array(waist).astype(np.float64).reshape(-1)
+        if left_arm.shape[0] != 7 or right_arm.shape[0] != 7:
+            raise RuntimeError(
+                'RoboCasa arm states must each contain 7 values.')
+        if waist.shape[0] != 3:
+            raise RuntimeError('RoboCasa waist state must contain 3 values.')
+
+        left_target = self._apply_delta(left_arm, command, 'left_arm_delta',
+                                        self.max_arm_joint_delta,
+                                        self.left_arm_joint_bounds)
+        right_target = self._apply_delta(right_arm, command, 'right_arm_delta',
+                                         self.max_arm_joint_delta,
+                                         self.right_arm_joint_bounds)
+        waist_target = self._apply_delta(waist, command, 'waist_delta',
+                                         self.max_waist_joint_delta,
+                                         self.waist_joint_bounds)
+        left_hand_target = self._hand_action(
+            command.get('left_hand', 'hold'), 'left')
+        right_hand_target = self._hand_action(
+            command.get('right_hand', 'hold'), 'right')
+        action = np.concatenate([
+            left_target, right_target, left_hand_target, right_hand_target,
+            waist_target
+        ]).astype(np.float32)
+        actions = np.repeat(action[None], self.action_horizon, axis=0)
+        return torch.from_numpy(actions).unsqueeze(0)
+
+    def _hold_robocasa_actions(self, left_arm: Any, right_arm: Any,
+                               waist: Any) -> torch.Tensor:
+        return self._robocasa_actions({}, left_arm, right_arm, waist)
+
+    @torch.inference_mode()
+    def predict_action(self,
+                       images: Sequence[Any],
+                       task_description: str,
+                       left_arm: Any,
+                       left_hand: Any,
+                       right_arm: Any,
+                       right_hand: Any,
+                       waist: Any,
+                       image_names: Sequence[str] = None,
+                       reset_history: bool = False,
+                       **kwargs) -> torch.Tensor:
+        del kwargs
+        task_description = self._unbatch_text(task_description)
+        if reset_history or self._task_description != task_description:
+            self._reset_episode(task_description)
+
+        if image_names is None:
+            image_names = [f'camera_{index}' for index in range(len(images))]
+        elif (isinstance(image_names, (list, tuple)) and len(image_names) == 1
+              and isinstance(image_names[0], (list, tuple))):
+            image_names = image_names[0]
+
+        if self._llm_calls >= self.max_llm_calls:
+            if not self._budget_warning_emitted:
+                overwatch.warning(
+                    f'OpenAI call budget ({self.max_llm_calls}) exhausted; '
+                    'returning GR1 hold actions for the rest of the episode.')
+                self._budget_warning_emitted = True
+            return self._hold_robocasa_actions(left_arm, right_arm, waist)
+
+        self._history.append(
+            self._robocasa_observation_message(images, image_names,
+                                               task_description, left_arm,
+                                               left_hand, right_arm,
+                                               right_hand, waist))
+        start = time.monotonic()
+        response = self._post_json(self._request_body())
+        latency = time.monotonic() - start
+        self._llm_calls += 1
+        call = self._robocasa_function_call(response)
+        try:
+            command = json.loads(call.get('arguments', '{}'))
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f'Invalid control_gr1 arguments: '
+                               f'{call.get("arguments")!r}') from exc
+        if not isinstance(command, dict):
+            raise RuntimeError('control_gr1 arguments must be an object')
+        self.last_note = str(command.get('note', ''))
+        usage = response.get('usage') or {}
+        self.last_response_metadata = {
+            'id': response.get('id'),
+            'model': response.get('model', self.model),
+            'latency_seconds': latency,
+            'input_tokens': usage.get('input_tokens'),
+            'output_tokens': usage.get('output_tokens'),
+        }
+        logged_command = {
+            key: value
+            for key, value in command.items() if key != 'note'
+        }
+        overwatch.info(
+            f'GPT RoboCasa action {self._llm_calls}/{self.max_llm_calls}: '
+            f'{logged_command} | {self.last_note}')
+
+        call_id = call.get('call_id')
+        self._history.append({
+            'type': 'function_call',
+            'call_id': call_id,
+            'name': 'control_gr1',
+            'arguments': call.get('arguments', '{}'),
+        })
+        actions = self._robocasa_actions(command, left_arm, right_arm, waist)
+        self._history.append({
+            'type':
+            'function_call_output',
+            'call_id':
+            call_id,
+            'output':
+            f'executing control_gr1 over {actions.shape[1]} steps',
         })
         return actions

--- a/fluxvla/transforms/__init__.py
+++ b/fluxvla/transforms/__init__.py
@@ -19,8 +19,9 @@ from .normalize import *  # noqa: F401, F403
 from .prompters import *  # noqa: F401, F403
 from .qwen_vl_action_inputs import *  # noqa: F401, F403
 from .robocasa_transforms import (  # noqa: F401, F403
-    DenormalizeRobocasaAction, ProcessRobocasaEvalInputs, RobocasaEvalDataset,
-    RobocasaGR1N15Bridge, flatten_robocasa_state)
+    DenormalizeRobocasaAction, IdentityRobocasaAction,
+    ProcessRobocasaEvalInputs, RobocasaEvalDataset, RobocasaGR1N15Bridge,
+    flatten_robocasa_state)
 from .transform_actions import *  # noqa: F401, F403
 from .transform_cosmos3 import *  # noqa: F401, F403
 from .transform_images import *  # noqa: F401, F403

--- a/fluxvla/transforms/robocasa_transforms.py
+++ b/fluxvla/transforms/robocasa_transforms.py
@@ -423,6 +423,26 @@ class DenormalizeRobocasaAction:
         return 0.5 * (action + 1) * (high - low) + low
 
 
+@TRANSFORMS.register_module()
+class IdentityRobocasaAction:
+    """Return native RoboCasa action targets without denormalization."""
+
+    def __init__(self,
+                 norm_stats=None,
+                 action_dim: int = 29,
+                 clip: bool = False) -> None:
+        del norm_stats
+        self.action_dim = int(action_dim)
+        self.clip = bool(clip)
+
+    def __call__(self, data: Dict) -> np.ndarray:
+        action = np.asarray(data['action'], dtype=np.float32)
+        action = action[..., :self.action_dim]
+        if self.clip:
+            action = np.clip(action, -1.0, 1.0)
+        return action
+
+
 @DATASETS.register_module()
 class RobocasaEvalDataset:
     """RoboCasa eval dataset wrapper.


### PR DESCRIPTION
## Summary

Extend GPT-6 Astra inference-only evaluation to RoboCasa and improve LIBERO configuration coverage and robot control.

## Changes

- Add checkpoint-free RoboCasa GR1 evaluation with bounded arm/waist joint commands and hand control, mapped to native 29D actions.
- Add configurations for all 24 RoboCasa tasks and LIBERO Spatial, Object, Goal, and LIBERO-10 suites.
- Evaluate all tasks by default, with configurable episodes per task.
- Fix missing LIBERO wrist rotation by exposing world-frame rotation commands with independent angular speed limits.
- Validate LIBERO tool arguments and adapt planning guidance to the configured API call budget.
- Read API credentials and endpoint settings from environment variables.
- Fix concurrent LIBERO initialization and per-rank CUDA binding for CPU-hosted API policies.
- Document the control interface and simulator validation workflow.

## Validation

- 77 local regression tests passed.
- 11 real LIBERO simulator checks passed, covering rotation, translation, and gripper control.
- 12 real RoboCasa wrist checks passed across both arms, all three wrist joints, and both directions.

Controller checks used scripted commands without hosted API calls. Full GPT benchmark success rates have not been re-evaluated after the rotation fix.